### PR TITLE
fix: use TARGET_OS_OSX instead of TARGET_OS_MAC for macOS-only code

### DIFF
--- a/Sources/LookinCore/Category/Color+Lookin.h
+++ b/Sources/LookinCore/Category/Color+Lookin.h
@@ -11,7 +11,7 @@
 
 #if TARGET_OS_IPHONE
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 
 #import <AppKit/AppKit.h>
 

--- a/Sources/LookinCore/Category/Color+Lookin.m
+++ b/Sources/LookinCore/Category/Color+Lookin.m
@@ -11,7 +11,7 @@
 
 #if TARGET_OS_IPHONE
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 
 @implementation NSColor (Lookin)
 

--- a/Sources/LookinCore/Category/Image+Lookin.h
+++ b/Sources/LookinCore/Category/Image+Lookin.h
@@ -11,7 +11,7 @@
 
 #if TARGET_OS_IPHONE
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 
 #import <AppKit/AppKit.h>
 

--- a/Sources/LookinCore/Category/Image+Lookin.m
+++ b/Sources/LookinCore/Category/Image+Lookin.m
@@ -11,7 +11,7 @@
 
 #if TARGET_OS_IPHONE
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 
 @implementation NSImage (LookinClient)
 

--- a/Sources/LookinCore/Category/NSObject+Lookin.m
+++ b/Sources/LookinCore/Category/NSObject+Lookin.m
@@ -117,7 +117,7 @@ static char kAssociatedObjectKey_LookinAllBindObjects;
 - (void)lookin_bindPoint:(CGPoint)pointValue forKey:(NSString *)key {
 #if TARGET_OS_IPHONE
     [self lookin_bindObject:[NSValue valueWithCGPoint:pointValue] forKey:key];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     NSPoint nsPoint = NSMakePoint(pointValue.x, pointValue.y);
     [self lookin_bindObject:[NSValue valueWithPoint:nsPoint] forKey:key];
 #endif
@@ -128,7 +128,7 @@ static char kAssociatedObjectKey_LookinAllBindObjects;
     if ([object isKindOfClass:[NSValue class]]) {
 #if TARGET_OS_IPHONE
         CGPoint pointValue = [(NSValue *)object CGPointValue];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
         NSPoint nsPointValue = [(NSValue *)object pointValue];
         CGPoint pointValue = CGPointMake(nsPointValue.x, nsPointValue.y);
 #endif
@@ -165,7 +165,7 @@ static char kAssociatedObjectKey_LookinAllBindObjects;
                 b = 0;
                 a = 0;
             }
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
             NSColor *color = [((NSColor *)self) colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
             [color getRed:&r green:&g blue:&b alpha:&a];
 #endif
@@ -187,7 +187,7 @@ static char kAssociatedObjectKey_LookinAllBindObjects;
             NSAssert(NO, @"");
             return nil;
         }
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
         if ([self isKindOfClass:[NSImage class]]) {
             NSImage *image = (NSImage *)self;
             return [image TIFFRepresentation];

--- a/Sources/LookinCore/Category/NSSet+Lookin.h
+++ b/Sources/LookinCore/Category/NSSet+Lookin.h
@@ -15,7 +15,7 @@
 #import "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 

--- a/Sources/LookinCore/Category/NSString+Lookin.m
+++ b/Sources/LookinCore/Category/NSString+Lookin.m
@@ -64,7 +64,7 @@
     
 #if TARGET_OS_IPHONE
     UIColor *rgbColor = color;
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     NSColor *rgbColor = [color colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
 #endif
     

--- a/Sources/LookinCore/LookinAppInfo.m
+++ b/Sources/LookinCore/LookinAppInfo.m
@@ -43,7 +43,11 @@ static NSString * const CodingKey_DeviceType = @"8";
     if (strcmp(returnType, @encode(CGRect)) == 0) {
         CGRect value = CGRectZero;
         [invocation getReturnValue:&value];
+#if TARGET_OS_OSX
         return [NSValue valueWithRect:value];
+#else
+        return [NSValue valueWithCGRect:value];
+#endif
     }
     if (strcmp(returnType, @encode(CGFloat)) == 0 || strcmp(returnType, @encode(double)) == 0) {
         CGFloat value = 0;
@@ -115,7 +119,7 @@ static NSString * const CodingKey_DeviceType = @"8";
     
     NSData *appIconData = UIImagePNGRepresentation(self.appIcon);
     [aCoder encodeObject:appIconData forKey:CodingKey_AppIcon];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     NSData *screenshotData = [self.screenshot TIFFRepresentation];
     [aCoder encodeObject:screenshotData forKey:CodingKey_Screenshot];
     
@@ -189,7 +193,7 @@ static NSString * const CodingKey_DeviceType = @"8";
     info.appInfoIdentifier = selfIdentifier;
     info.appName = [self appName];
     info.appBundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
     info.deviceDescription = [self _invokeAdapterSelector:@"deviceDescription"] ?: @"Mac";
     info.deviceType = LookinAppInfoDeviceMac;
     info.osDescription = [self _invokeAdapterSelector:@"operatingSystemDescription"] ?: @"macOS";
@@ -198,7 +202,7 @@ static NSString * const CodingKey_DeviceType = @"8";
     info.deviceDescription = [UIDevice currentDevice].name;
     if ([self isSimulator]) {
         info.deviceType = LookinAppInfoDeviceSimulator;
-    } else if ([LKS_MultiplatformAdapter isiPad]) {
+    } else if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
         info.deviceType = LookinAppInfoDeviceIPad;
     } else {
         info.deviceType = LookinAppInfoDeviceOthers;
@@ -209,7 +213,7 @@ static NSString * const CodingKey_DeviceType = @"8";
 #endif
     
     CGRect screenBounds = CGRectZero;
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
     screenBounds = [(NSValue *)[self _invokeAdapterSelector:@"mainScreenBounds"] rectValue];
 #else
     screenBounds = [(NSValue *)[self _invokeAdapterSelector:@"mainScreenBounds"] CGRectValue];
@@ -245,7 +249,7 @@ static NSString * const CodingKey_DeviceType = @"8";
 + (LookinImage *)appIcon {
 #if TARGET_OS_TV
     return nil;
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     NSImage *icon = [NSApp applicationIconImage];
     if (icon) {
         return icon;
@@ -275,7 +279,7 @@ static NSString * const CodingKey_DeviceType = @"8";
 }
 
 + (LookinImage *)screenshotImage {
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
     NSWindow *window = [self _invokeAdapterSelector:@"keyWindow"];
     if (!window) {
         return nil;
@@ -295,7 +299,7 @@ static NSString * const CodingKey_DeviceType = @"8";
     [invocation getReturnValue:&image];
     return image;
 #else
-    UIWindow *window = [LKS_MultiplatformAdapter keyWindow];
+    UIWindow *window = [self _invokeAdapterSelector:@"keyWindow"];
     if (!window) {
         return nil;
     }

--- a/Sources/LookinCore/LookinCustomDisplayItemInfo.m
+++ b/Sources/LookinCore/LookinCustomDisplayItemInfo.m
@@ -21,7 +21,7 @@
 #if TARGET_OS_IPHONE
         CGRect rect = [self.frameInWindow CGRectValue];
         newInstance.frameInWindow = [NSValue valueWithCGRect:rect];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
         CGRect rect = [self.frameInWindow rectValue];
         newInstance.frameInWindow = [NSValue valueWithRect:rect];
 #endif

--- a/Sources/LookinCore/LookinDefines.h
+++ b/Sources/LookinCore/LookinDefines.h
@@ -11,7 +11,7 @@
 #import "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 
@@ -148,7 +148,7 @@ enum {
 #define LookinColor UIColor
 #define LookinInsets UIEdgeInsets
 #define LookinImage UIImage
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #define LookinColor NSColor
 #define LookinInsets NSEdgeInsets
 #define LookinImage NSImage

--- a/Sources/LookinCore/LookinDisplayItem.h
+++ b/Sources/LookinCore/LookinDisplayItem.h
@@ -14,7 +14,7 @@
 #import "LookinCustomDisplayItemInfo.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 

--- a/Sources/LookinCore/LookinDisplayItem.m
+++ b/Sources/LookinCore/LookinDisplayItem.m
@@ -22,7 +22,7 @@
 #if TARGET_OS_IPHONE
 #import "../LookinServer/Server/Category/UIColor+LookinServer.h"
 #import "../LookinServer/Server/Category/UIImage+LookinServer.h"
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #endif
 
 @interface LookinDisplayItem ()
@@ -100,7 +100,7 @@
     [aCoder encodeCGRect:self.bounds forKey:@"bounds"];
     [aCoder encodeObject:self.backgroundColor.lks_rgbaComponents forKey:@"backgroundColor"];
     
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     [aCoder encodeRect:self.frame forKey:@"frame"];
     [aCoder encodeRect:self.bounds forKey:@"bounds"];
     [aCoder encodeObject:self.backgroundColor.lookin_rgbaComponents forKey:@"backgroundColor"];
@@ -151,7 +151,7 @@
         self.frame = [aDecoder decodeCGRectForKey:@"frame"];
         self.bounds = [aDecoder decodeCGRectForKey:@"bounds"];
         self.backgroundColor = [UIColor lks_colorFromRGBAComponents:[aDecoder decodeObjectForKey:@"backgroundColor"]];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
         self.frame = [aDecoder decodeRectForKey:@"frame"];
         self.bounds = [aDecoder decodeRectForKey:@"bounds"];
         self.backgroundColor = [NSColor lookin_colorFromRGBAComponents:[aDecoder decodeObjectForKey:@"backgroundColor"]];

--- a/Sources/LookinCore/LookinHierarchyInfo.h
+++ b/Sources/LookinCore/LookinHierarchyInfo.h
@@ -14,7 +14,7 @@
 #import "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 

--- a/Sources/LookinServer/Server/Category/CALayer+LookinServer.h
+++ b/Sources/LookinServer/Server/Category/CALayer+LookinServer.h
@@ -9,13 +9,13 @@
 
 #import "LookinDefines.h"
 #import "TargetConditionals.h"
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #else
 #import <UIKit/UIKit.h>
 #endif
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #define LKSPlatformView NSView
 #define LKSPlatformWindow NSWindow
 #else

--- a/Sources/LookinServer/Server/Category/CALayer+LookinServer.m
+++ b/Sources/LookinServer/Server/Category/CALayer+LookinServer.m
@@ -11,9 +11,13 @@
 #import "NSArray+Lookin.h"
 #import "LookinIvarTrace.h"
 #import "NSObject+LookinServer.h"
+#if !TARGET_OS_OSX
+#import "UIColor+LookinServer.h"
+#endif
 
 @implementation CALayer (LookinServer)
 
+#if TARGET_OS_OSX
 static NSArray<NSView *> *LKHideVisibleSubviews(NSArray<NSView *> *subviews) {
     NSMutableArray<NSView *> *hiddenSubviews = [NSMutableArray array];
     for (NSView *subview in subviews.copy) {
@@ -24,6 +28,7 @@ static NSArray<NSView *> *LKHideVisibleSubviews(NSArray<NSView *> *subviews) {
     }
     return hiddenSubviews.copy;
 }
+#endif
 
 static NSArray<CALayer *> *LKHideVisibleNonHostSublayers(NSArray<CALayer *> *sublayers) {
     NSMutableArray<CALayer *> *hiddenSublayers = [NSMutableArray array];
@@ -37,11 +42,13 @@ static NSArray<CALayer *> *LKHideVisibleNonHostSublayers(NSArray<CALayer *> *sub
     return hiddenSublayers.copy;
 }
 
+#if TARGET_OS_OSX
 static void LKRestoreHiddenViews(NSArray<NSView *> *subviews) {
     for (NSView *subview in subviews) {
         subview.hidden = NO;
     }
 }
+#endif
 
 static void LKRestoreHiddenLayers(NSArray<CALayer *> *sublayers) {
     for (CALayer *sublayer in sublayers) {
@@ -58,7 +65,7 @@ static void LKRestoreHiddenLayers(NSArray<CALayer *> *sublayers) {
     return completedList;
 }
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 
 - (NSWindow *)lks_window {
     CALayer *layer = self;

--- a/Sources/LookinServer/Server/Category/NSObject+LookinServer.h
+++ b/Sources/LookinServer/Server/Category/NSObject+LookinServer.h
@@ -9,7 +9,7 @@
 
 #import "LookinDefines.h"
 #import <Foundation/Foundation.h>
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 
@@ -42,7 +42,7 @@
 
 @end
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 
 @interface NSView (LookinServer)
 

--- a/Sources/LookinServer/Server/Category/NSObject+LookinServer.m
+++ b/Sources/LookinServer/Server/Category/NSObject+LookinServer.m
@@ -12,7 +12,7 @@
 #import "NSArray+Lookin.h"
 #import "LookinServerDefines.h"
 #import "LKS_ObjectRegistry.h"
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import "LookinObject.h"
 #import "LookinAutoLayoutConstraint.h"
 #import "LKS_MultiplatformAdapter.h"
@@ -105,7 +105,7 @@
 
 @end
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 
 static const void *LKUserInteractionEnabledKey = &LKUserInteractionEnabledKey;
 static const void *LKContentModeKey = &LKContentModeKey;

--- a/Sources/LookinServer/Server/Connection/LKS_ConnectionManager.h
+++ b/Sources/LookinServer/Server/Connection/LKS_ConnectionManager.h
@@ -7,7 +7,7 @@
 //  https://lookin.work
 //
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #else
 #import <UIKit/UIKit.h>

--- a/Sources/LookinServer/Server/Connection/LKS_ConnectionManager.m
+++ b/Sources/LookinServer/Server/Connection/LKS_ConnectionManager.m
@@ -13,6 +13,10 @@
 #import "LookinDefines.h"
 #import "LookinConnectionResponseAttachment.h"
 #import "LKS_MultiplatformAdapter.h"
+#if !TARGET_OS_OSX
+#import "LKS_ExportManager.h"
+#import "LKS_TraceManager.h"
+#endif
 
 NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNotificationName";
 
@@ -44,7 +48,7 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
     if (self = [super init]) {
         NSLog(@"LookinServer - Will launch. Framework version: %@", LOOKIN_SERVER_READABLE_VERSION);
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_handleApplicationDidBecomeActive) name:NSApplicationDidBecomeActiveNotification object:nil];
 #else
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_handleApplicationDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
@@ -52,7 +56,7 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
 #endif
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_handleLocalInspect:) name:@"Lookin_2D" object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_handleLocalInspect:) name:@"Lookin_3D" object:nil];
-#if !TARGET_OS_MAC
+#if !TARGET_OS_OSX
         [[NSNotificationCenter defaultCenter] addObserverForName:@"Lookin_Export" object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
             [[LKS_ExportManager sharedInstance] exportAndShare];
         }];
@@ -64,7 +68,7 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
         
         self.requestHandler = [LKS_RequestHandler new];
         self.preferredListenPort = LookinUSBDeviceIPv4PortNumberStart;
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
         self.preferredListenPort = LookinMacIPv4PortNumberStart;
         self.applicationIsActive = YES;
         [self searchPortToListenIfNoConnection];
@@ -76,7 +80,7 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
 }
 
 - (void)_handleWillResignActiveNotification {
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
     // macOS targets remain inspectable even when they are not the frontmost app.
     return;
 #else
@@ -103,7 +107,7 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
     [self.peerChannel_ close];
     self.peerChannel_ = nil;
     
-    if (TARGET_OS_MAC) {
+    if (TARGET_OS_OSX) {
         [self _tryToListenWithPreferredPort:self.preferredListenPort
                                    fromPort:LookinMacIPv4PortNumberStart
                                      toPort:LookinMacIPv4PortNumberEnd];
@@ -119,7 +123,7 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
 }
 
 - (BOOL)isiOSAppOnMac {
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
     return NO;
 #else
 #if TARGET_OS_SIMULATOR
@@ -272,7 +276,7 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
 #pragma mark - Handler
 
 - (void)_handleLocalInspect:(NSNotification *)note {
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
     NSAlert *alert = [[NSAlert alloc] init];
     alert.messageText = @"LookInside";
     alert.informativeText = @"Failed to run local inspection. The feature has been removed. Please use the desktop client or CLI.";

--- a/Sources/LookinServer/Server/Connection/LKS_RequestHandler.m
+++ b/Sources/LookinServer/Server/Connection/LKS_RequestHandler.m
@@ -21,7 +21,7 @@
 #import "LKS_HierarchyDetailsHandler.h"
 #import <objc/runtime.h>
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import "Image+Lookin.h"
 #else
 #import "UIImage+LookinServer.h"
@@ -77,7 +77,7 @@
 - (void)handleRequestType:(uint32_t)requestType tag:(uint32_t)tag object:(id)object {
     if (requestType == LookinRequestTypePing) {
         LookinConnectionResponseAttachment *attachment = [LookinConnectionResponseAttachment new];
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
         attachment.appIsInBackground = NO;
 #else
         attachment.appIsInBackground = ![LKS_ConnectionManager sharedInstance].applicationIsActive;
@@ -217,7 +217,7 @@
     }
 
     if (requestType == LookinRequestTypeFetchImageViewImage) {
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
         NSImageView *imageView = (NSImageView *)[NSObject lks_objectWithOid:[(NSNumber *)object unsignedLongValue]];
         if (![imageView isKindOfClass:[NSImageView class]] || !imageView.image) {
             [self _respondWithError:LookinErr_ObjNotFound requestType:requestType tag:tag];

--- a/Sources/LookinServer/Server/Connection/RequestHandler/LKS_HierarchyDetailsHandler.m
+++ b/Sources/LookinServer/Server/Connection/RequestHandler/LKS_HierarchyDetailsHandler.m
@@ -14,7 +14,7 @@
 #import "CALayer+LookinServer.h"
 #import "LKS_AttrGroupsMaker.h"
 #import "LKS_HierarchyDisplayItemsMaker.h"
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import "LKS_MultiplatformAdapter.h"
 #endif
 
@@ -26,7 +26,7 @@
 
 @implementation LKS_HierarchyDetailsHandler
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 static NSArray<NSView *> *LKDetailHideVisibleSubviews(NSArray<NSView *> *subviews) {
     NSMutableArray<NSView *> *hiddenSubviews = [NSMutableArray array];
     for (NSView *subview in subviews.copy) {
@@ -78,7 +78,7 @@ static NSImage *LKDetailSnapshotImageForView(NSView *view) {
             LookinDisplayItemDetail *detail = [LookinDisplayItemDetail new];
             detail.displayItemOid = task.oid;
             NSObject *targetObject = [NSObject lks_objectWithOid:task.oid];
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
             if ([targetObject isKindOfClass:NSView.class]) {
                 NSView *view = (NSView *)targetObject;
                 if (task.taskType == LookinStaticAsyncUpdateTaskTypeSoloScreenshot && view.subviews.count) {
@@ -124,8 +124,13 @@ static NSImage *LKDetailSnapshotImageForView(NSView *view) {
                     detail.groupScreenshot = [layer lks_groupScreenshotWithLowQuality:NO];
                 }
                 if (task.needBasisVisualInfo) {
+#if TARGET_OS_OSX
                     detail.frameValue = [NSValue valueWithRect:layer.frame];
                     detail.boundsValue = [NSValue valueWithRect:layer.bounds];
+#else
+                    detail.frameValue = [NSValue valueWithCGRect:layer.frame];
+                    detail.boundsValue = [NSValue valueWithCGRect:layer.bounds];
+#endif
                     detail.hiddenValue = @(layer.hidden);
                     detail.alphaValue = @(layer.opacity);
                 }

--- a/Sources/LookinServer/Server/Connection/RequestHandler/LKS_InbuiltAttrModificationHandler.m
+++ b/Sources/LookinServer/Server/Connection/RequestHandler/LKS_InbuiltAttrModificationHandler.m
@@ -16,7 +16,7 @@
 #import "CALayer+LookinServer.h"
 #import "LookinServerDefines.h"
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import "Color+Lookin.h"
 
 @implementation LKS_InbuiltAttrModificationHandler

--- a/Sources/LookinServer/Server/Others/LKS_AttrGroupsMaker.h
+++ b/Sources/LookinServer/Server/Others/LKS_AttrGroupsMaker.h
@@ -10,13 +10,13 @@
 #import "LookinDefines.h"
 
 @class LookinAttributesGroup;
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 @class NSView, NSWindow;
 #endif
 
 @interface LKS_AttrGroupsMaker : NSObject
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 
 + (NSArray<LookinAttributesGroup *> *)attrGroupsForView:(NSView *)view;
 

--- a/Sources/LookinServer/Server/Others/LKS_AttrGroupsMaker.m
+++ b/Sources/LookinServer/Server/Others/LKS_AttrGroupsMaker.m
@@ -14,7 +14,7 @@
 #import "LookinDashboardBlueprint.h"
 #import "CALayer+LookinServer.h"
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import "Color+Lookin.h"
 #import "NSObject+LookinServer.h"
 #import "LookinIvarTrace.h"

--- a/Sources/LookinServer/Server/Others/LKS_HierarchyDisplayItemsMaker.m
+++ b/Sources/LookinServer/Server/Others/LKS_HierarchyDisplayItemsMaker.m
@@ -15,7 +15,7 @@
 #import "NSObject+LookinServer.h"
 #import "LKS_MultiplatformAdapter.h"
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 
 @implementation LKS_HierarchyDisplayItemsMaker
 

--- a/Sources/LookinServer/Server/Others/LKS_MultiplatformAdapter.h
+++ b/Sources/LookinServer/Server/Others/LKS_MultiplatformAdapter.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #else
 #import <UIKit/UIKit.h>
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface LKS_MultiplatformAdapter : NSObject
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 
 + (NSWindow *)keyWindow;
 

--- a/Sources/LookinServer/Server/Others/LKS_MultiplatformAdapter.m
+++ b/Sources/LookinServer/Server/Others/LKS_MultiplatformAdapter.m
@@ -7,7 +7,7 @@
 //
 
 #import "LKS_MultiplatformAdapter.h"
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #else
 #import <UIKit/UIKit.h>
@@ -15,7 +15,7 @@
 
 @implementation LKS_MultiplatformAdapter
 
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
 
 + (NSWindow *)keyWindow {
     NSWindow *keyWindow = NSApplication.sharedApplication.keyWindow;

--- a/Sources/LookinServer/Shared/Category/Color+Lookin.h
+++ b/Sources/LookinServer/Shared/Category/Color+Lookin.h
@@ -11,7 +11,7 @@
 
 #if TARGET_OS_IPHONE
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 
 @interface NSColor (Lookin)
 

--- a/Sources/LookinServer/Shared/Category/Color+Lookin.m
+++ b/Sources/LookinServer/Shared/Category/Color+Lookin.m
@@ -11,7 +11,7 @@
 
 #if TARGET_OS_IPHONE
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 
 @implementation NSColor (Lookin)
 

--- a/Sources/LookinServer/Shared/Category/Image+Lookin.h
+++ b/Sources/LookinServer/Shared/Category/Image+Lookin.h
@@ -11,7 +11,7 @@
 
 #if TARGET_OS_IPHONE
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 
 @interface NSImage (LookinClient)
 

--- a/Sources/LookinServer/Shared/Category/Image+Lookin.m
+++ b/Sources/LookinServer/Shared/Category/Image+Lookin.m
@@ -11,7 +11,7 @@
 
 #if TARGET_OS_IPHONE
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 
 @implementation NSImage (LookinClient)
 

--- a/Sources/LookinServer/Shared/Category/NSObject+Lookin.m
+++ b/Sources/LookinServer/Shared/Category/NSObject+Lookin.m
@@ -117,7 +117,7 @@ static char kAssociatedObjectKey_LookinAllBindObjects;
 - (void)lookin_bindPoint:(CGPoint)pointValue forKey:(NSString *)key {
 #if TARGET_OS_IPHONE
     [self lookin_bindObject:[NSValue valueWithCGPoint:pointValue] forKey:key];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     NSPoint nsPoint = NSMakePoint(pointValue.x, pointValue.y);
     [self lookin_bindObject:[NSValue valueWithPoint:nsPoint] forKey:key];
 #endif
@@ -128,7 +128,7 @@ static char kAssociatedObjectKey_LookinAllBindObjects;
     if ([object isKindOfClass:[NSValue class]]) {
 #if TARGET_OS_IPHONE
         CGPoint pointValue = [(NSValue *)object CGPointValue];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
         NSPoint nsPointValue = [(NSValue *)object pointValue];
         CGPoint pointValue = CGPointMake(nsPointValue.x, nsPointValue.y);
 #endif
@@ -165,7 +165,7 @@ static char kAssociatedObjectKey_LookinAllBindObjects;
                 b = 0;
                 a = 0;
             }
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
             NSColor *color = [((NSColor *)self) colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
             [color getRed:&r green:&g blue:&b alpha:&a];
 #endif
@@ -187,7 +187,7 @@ static char kAssociatedObjectKey_LookinAllBindObjects;
             NSAssert(NO, @"");
             return nil;
         }
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
         if ([self isKindOfClass:[NSImage class]]) {
             NSImage *image = (NSImage *)self;
             return [image TIFFRepresentation];

--- a/Sources/LookinServer/Shared/Category/NSSet+Lookin.h
+++ b/Sources/LookinServer/Shared/Category/NSSet+Lookin.h
@@ -15,7 +15,7 @@
 #import "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 

--- a/Sources/LookinServer/Shared/Category/NSString+Lookin.m
+++ b/Sources/LookinServer/Shared/Category/NSString+Lookin.m
@@ -64,7 +64,7 @@
     
 #if TARGET_OS_IPHONE
     UIColor *rgbColor = color;
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     NSColor *rgbColor = [color colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
 #endif
     

--- a/Sources/LookinServer/Shared/LookinAppInfo.m
+++ b/Sources/LookinServer/Shared/LookinAppInfo.m
@@ -77,7 +77,7 @@ static NSString * const CodingKey_DeviceType = @"8";
     
     NSData *appIconData = UIImagePNGRepresentation(self.appIcon);
     [aCoder encodeObject:appIconData forKey:CodingKey_AppIcon];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     NSData *screenshotData = [self.screenshot TIFFRepresentation];
     [aCoder encodeObject:screenshotData forKey:CodingKey_Screenshot];
     

--- a/Sources/LookinServer/Shared/LookinCustomDisplayItemInfo.m
+++ b/Sources/LookinServer/Shared/LookinCustomDisplayItemInfo.m
@@ -21,7 +21,7 @@
 #if TARGET_OS_IPHONE
         CGRect rect = [self.frameInWindow CGRectValue];
         newInstance.frameInWindow = [NSValue valueWithCGRect:rect];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
         CGRect rect = [self.frameInWindow rectValue];
         newInstance.frameInWindow = [NSValue valueWithRect:rect];
 #endif

--- a/Sources/LookinServer/Shared/LookinDefines.h
+++ b/Sources/LookinServer/Shared/LookinDefines.h
@@ -11,7 +11,7 @@
 #import "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 
@@ -144,7 +144,7 @@ enum {
 #define LookinColor UIColor
 #define LookinInsets UIEdgeInsets
 #define LookinImage UIImage
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #define LookinColor NSColor
 #define LookinInsets NSEdgeInsets
 #define LookinImage NSImage

--- a/Sources/LookinServer/Shared/LookinDisplayItem.h
+++ b/Sources/LookinServer/Shared/LookinDisplayItem.h
@@ -14,7 +14,7 @@
 #import "LookinCustomDisplayItemInfo.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 

--- a/Sources/LookinServer/Shared/LookinDisplayItem.m
+++ b/Sources/LookinServer/Shared/LookinDisplayItem.m
@@ -22,7 +22,7 @@
 #if TARGET_OS_IPHONE
 #import "UIColor+LookinServer.h"
 #import "UIImage+LookinServer.h"
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #endif
 
 @interface LookinDisplayItem ()
@@ -100,7 +100,7 @@
     [aCoder encodeCGRect:self.bounds forKey:@"bounds"];
     [aCoder encodeObject:self.backgroundColor.lks_rgbaComponents forKey:@"backgroundColor"];
     
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
     [aCoder encodeRect:self.frame forKey:@"frame"];
     [aCoder encodeRect:self.bounds forKey:@"bounds"];
     [aCoder encodeObject:self.backgroundColor.lookin_rgbaComponents forKey:@"backgroundColor"];
@@ -151,7 +151,7 @@
         self.frame = [aDecoder decodeCGRectForKey:@"frame"];
         self.bounds = [aDecoder decodeCGRectForKey:@"bounds"];
         self.backgroundColor = [UIColor lks_colorFromRGBAComponents:[aDecoder decodeObjectForKey:@"backgroundColor"]];
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
         self.frame = [aDecoder decodeRectForKey:@"frame"];
         self.bounds = [aDecoder decodeRectForKey:@"bounds"];
         self.backgroundColor = [NSColor lookin_colorFromRGBAComponents:[aDecoder decodeObjectForKey:@"backgroundColor"]];

--- a/Sources/LookinServer/Shared/LookinHierarchyInfo.h
+++ b/Sources/LookinServer/Shared/LookinHierarchyInfo.h
@@ -14,7 +14,7 @@
 #import "TargetConditionals.h"
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif
 


### PR DESCRIPTION
## Summary

Fix iOS compilation failures introduced in 2.1.0 by replacing `TARGET_OS_MAC` with `TARGET_OS_OSX` for macOS-only platform guards.

## Problem

`TARGET_OS_MAC` is `1` on **all** Apple platforms (macOS, iOS, tvOS, watchOS, visionOS), not just macOS. The 2.1.0 release (`1bd1956 Add AppKit probe and extend LookinServer`) added macOS support using `#if TARGET_OS_MAC` to guard AppKit-specific code, but this causes the macOS code paths to compile on iOS too, resulting in compilation errors (AppKit imports, `NSWindow`, `NSImage`, `NSApp`, etc.).

## Changes

- Replace 67 standalone `TARGET_OS_MAC` → `TARGET_OS_OSX` across 40 files in `Sources/`
- Add platform guard for `valueWithRect:` / `valueWithCGRect:` in `LookinCore/LookinAppInfo.m` (had no guard at all)
- Replace direct `LKS_MultiplatformAdapter` references in `LookinCore` with dynamic dispatch (`UIDevice` API and `_invokeAdapterSelector:`)
- Fix runtime check `if (TARGET_OS_MAC)` → `if (TARGET_OS_OSX)` in `LKS_ConnectionManager.m`
- Compound expressions like `TARGET_OS_IPHONE || TARGET_OS_MAC` left as-is (correctly means "any Apple platform")

## Test plan

- [x] Build for iOS Simulator — should compile without errors
- [x] Build for macOS target — should still compile correctly
- [x] Verify LookinServer connects to Lookin.app from iOS target

🤖 Generated with [Claude Code](https://claude.com/claude-code)