### PR TITLE
fix: restore iOS port selection, screenshot delivery, and image fetch

### DIFF
--- a/Sources/LookinServer/Server/Connection/LKS_ConnectionManager.m
+++ b/Sources/LookinServer/Server/Connection/LKS_ConnectionManager.m
@@ -107,11 +107,12 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
     [self.peerChannel_ close];
     self.peerChannel_ = nil;
     
-    if (TARGET_OS_OSX) {
-        [self _tryToListenWithPreferredPort:self.preferredListenPort
-                                   fromPort:LookinMacIPv4PortNumberStart
-                                     toPort:LookinMacIPv4PortNumberEnd];
-    } else if ([self isiOSAppOnMac]) {
+#if TARGET_OS_OSX
+    [self _tryToListenWithPreferredPort:self.preferredListenPort
+                               fromPort:LookinMacIPv4PortNumberStart
+                                 toPort:LookinMacIPv4PortNumberEnd];
+#else
+    if ([self isiOSAppOnMac]) {
         [self _tryToListenWithPreferredPort:self.preferredListenPort
                                    fromPort:LookinSimulatorIPv4PortNumberStart
                                      toPort:LookinSimulatorIPv4PortNumberEnd];
@@ -120,6 +121,7 @@ NSString *const LKS_ConnectionDidEndNotificationName = @"LKS_ConnectionDidEndNot
                                    fromPort:LookinUSBDeviceIPv4PortNumberStart
                                      toPort:LookinUSBDeviceIPv4PortNumberEnd];
     }
+#endif
 }
 
 - (BOOL)isiOSAppOnMac {

--- a/Sources/LookinServer/Server/Connection/LKS_RequestHandler.m
+++ b/Sources/LookinServer/Server/Connection/LKS_RequestHandler.m
@@ -102,12 +102,16 @@
 
     if (requestType == LookinRequestTypeHierarchyDetails) {
         NSArray<LookinStaticAsyncUpdateTasksPackage *> *packages = [object isKindOfClass:[NSArray class]] ? object : @[];
+        NSUInteger responsesDataTotalCount = 0;
+        for (LookinStaticAsyncUpdateTasksPackage *package in packages) {
+            responsesDataTotalCount += package.tasks.count;
+        }
         LKS_HierarchyDetailsHandler *handler = [LKS_HierarchyDetailsHandler new];
         [self.activeDetailHandlers addObject:handler];
         [handler startWithPackages:packages block:^(NSArray<LookinDisplayItemDetail *> *details) {
             LookinConnectionResponseAttachment *attachment = [LookinConnectionResponseAttachment new];
             attachment.data = details;
-            attachment.dataTotalCount = details.count;
+            attachment.dataTotalCount = responsesDataTotalCount;
             attachment.currentDataCount = details.count;
             [[LKS_ConnectionManager sharedInstance] respond:attachment requestType:requestType tag:tag];
         } finishedBlock:^{
@@ -225,7 +229,12 @@
         }
         [self _respondWithData:imageView.image.lookin_data requestType:requestType tag:tag];
 #else
-        [self _respondWithError:LookinErr_Inner requestType:requestType tag:tag];
+        UIImageView *imageView = (UIImageView *)[NSObject lks_objectWithOid:[(NSNumber *)object unsignedLongValue]];
+        if (![imageView isKindOfClass:[UIImageView class]] || !imageView.image) {
+            [self _respondWithError:LookinErr_ObjNotFound requestType:requestType tag:tag];
+            return;
+        }
+        [self _respondWithData:[imageView.image lookin_data] requestType:requestType tag:tag];
 #endif
         return;
     }


### PR DESCRIPTION
## Summary

Fix three iOS regressions introduced in the 2.1.0 refactor of `LKS_ConnectionManager` and `LKS_RequestHandler`.

## Changes

### 1. Port selection — `LKS_ConnectionManager.m`

The original `if (TARGET_OS_MAC)` is a runtime check where `TARGET_OS_MAC` is always `1` on iOS, making the `else` branches dead code. PR #3 changed it to `if (TARGET_OS_OSX)` (`0` on iOS), which broke port selection.

**Fix**: Replace with preprocessor `#if TARGET_OS_OSX` / `#else` so each platform compiles only its correct code path at build time.

### 2. Screenshot delivery — `LKS_RequestHandler.m`

`dataTotalCount` was changed from the total task count across all packages to `details.count` (equal to `currentDataCount`). This tells the Lookin client that each batch is the final one, causing it to stop receiving after the first batch — the hierarchy structure shows up but all views are blank (screenshots arrive in later batches that get ignored).

**Fix**: Restore the original calculation that sums tasks across all packages.

### 3. Image fetch — `LKS_RequestHandler.m`

`LookinRequestTypeFetchImageViewImage` on iOS was replaced with a blanket error return, preventing UIImageView content from being fetched.

**Fix**: Restore the original iOS `UIImageView.image` fetch.

## Test plan

- [x] iOS: Lookin shows full view hierarchy with rendered screenshots
- [x] iOS: UIImageView images display correctly in Lookin
- [x] macOS: Build and Lookin inspection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)