### PR TITLE
Use Iris swift-demangling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ swift build -c debug --product lookinside
 ### App workspace
 
 ```bash
-xcodebuild -project LookInside.xcodeproj -scheme LookInside -configuration Debug -derivedDataPath /tmp/LookInsideDerivedData CODE_SIGNING_ALLOWED=NO build
+xcodebuild -skipMacroValidation -project LookInside.xcodeproj -scheme LookInside -configuration Debug -derivedDataPath /tmp/LookInsideDerivedData CODE_SIGNING_ALLOWED=NO build
 ```
 
 ## Release Expectations
@@ -66,7 +66,7 @@ Before calling a release-ready change complete:
 1. Run `bash Scripts/sync-derived-source.sh`.
 2. Run `swift build`.
 3. Run `swift build -c debug --product lookinside`.
-4. Run `xcodebuild -project LookInside.xcodeproj -scheme LookInside -configuration Debug -derivedDataPath /tmp/LookInsideDerivedData CODE_SIGNING_ALLOWED=NO build`.
+4. Run `xcodebuild -skipMacroValidation -project LookInside.xcodeproj -scheme LookInside -configuration Debug -derivedDataPath /tmp/LookInsideDerivedData CODE_SIGNING_ALLOWED=NO build`.
 5. Confirm `bash Scripts/test.sh` matches the current workspace/scheme paths, then run it.
 6. Smoke-check that the app launches, opens a target, and exports a hierarchy archive.
 7. Confirm README and dependency declarations match the actual workspace state.

--- a/LookInside.xcodeproj/project.pbxproj
+++ b/LookInside.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		50EAE1AA2F71C01A00EBE063 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA1CAA3D22E471EC006D9285 /* Security.framework */; };
 		50EAE1AB2F71C01A00EBE063 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB9517A22C3AECA00A5F958 /* Quartz.framework */; };
 		50EAE1AC2F71C01A00EBE063 /* QuickLookThumbnailing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB9519122C3BDC900A5F958 /* QuickLookThumbnailing.framework */; };
+		E37B8D0D2F97B1B100600001 /* Demangling in Frameworks */ = {isa = PBXBuildFile; productRef = E37B8D0C2F97B1B100600001 /* Demangling */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -618,6 +619,7 @@
 				50EAE1AA2F71C01A00EBE063 /* Security.framework in Frameworks */,
 				50EAE1AB2F71C01A00EBE063 /* Quartz.framework in Frameworks */,
 				50EAE1AC2F71C01A00EBE063 /* QuickLookThumbnailing.framework in Frameworks */,
+				E37B8D0D2F97B1B100600001 /* Demangling in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -668,6 +670,9 @@
 			dependencies = (
 			);
 			name = LookInside;
+			packageProductDependencies = (
+				E37B8D0C2F97B1B100600001 /* Demangling */,
+			);
 			productName = Lookin;
 			productReference = AA48F29B21CC0CA50032EC2C /* LookInside.app */;
 			productType = "com.apple.product-type.application";
@@ -707,6 +712,7 @@
 			);
 			mainGroup = AA48F29221CC0CA50032EC2C;
 			packageReferences = (
+				E37B8D0B2F97B1B100600001 /* XCRemoteSwiftPackageReference "swift-demangling" */,
 			);
 			preferredProjectObjectVersion = 50;
 			productRefGroup = AA48F29C21CC0CA50032EC2C /* Products */;
@@ -1052,6 +1058,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		E37B8D0B2F97B1B100600001 /* XCRemoteSwiftPackageReference "swift-demangling" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/MxIris-Reverse-Engineering/swift-demangling.git";
+			requirement = {
+				kind = exactVersion;
+				version = 0.2.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		E37B8D0C2F97B1B100600001 /* Demangling */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E37B8D0B2F97B1B100600001 /* XCRemoteSwiftPackageReference "swift-demangling" */;
+			productName = Demangling;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AA48F29321CC0CA50032EC2C /* Project object */;
 }

--- a/LookInside/Base/LKSwiftDemangler.swift
+++ b/LookInside/Base/LKSwiftDemangler.swift
@@ -7,35 +7,17 @@
 //
 
 import Foundation
+import Demangling
 
 public class LKSwiftDemangler: NSObject {
     private static var simpleCache: [String: String] = [:]
     private static var completedCache: [String: String] = [:]
 
-    @_silgen_name("swift_demangle")
-    private static func runtimeDemangle(
-        _ mangledName: UnsafePointer<UInt8>?,
-        _ mangledNameLength: UInt,
-        _ outputBuffer: UnsafeMutablePointer<UInt8>?,
-        _ outputBufferSize: UnsafeMutablePointer<Int>?,
-        _ flags: UInt32
-    ) -> UnsafeMutablePointer<Int8>?
-
     private static func demangle(_ input: String) -> String? {
-        guard !input.isEmpty else {
+        guard input.isSwiftSymbol else {
             return nil
         }
-        return input.utf8CString.withUnsafeBufferPointer { buffer in
-            guard let baseAddress = buffer.baseAddress else {
-                return nil
-            }
-            let mangledName = UnsafeRawPointer(baseAddress).assumingMemoryBound(to: UInt8.self)
-            guard let demangled = runtimeDemangle(mangledName, UInt(buffer.count - 1), nil, nil, 0) else {
-                return nil
-            }
-            defer { free(demangled) }
-            return String(cString: demangled)
-        }
+        return try? demangleAsNode(input).print(using: .default)
     }
 
     private static func simplify(_ demangled: String) -> String {

--- a/LookInside/Base/LKSwiftDemangler.swift
+++ b/LookInside/Base/LKSwiftDemangler.swift
@@ -13,22 +13,8 @@ public class LKSwiftDemangler: NSObject {
     private static var simpleCache: [String: String] = [:]
     private static var completedCache: [String: String] = [:]
 
-    private static func demangle(_ input: String) -> String? {
-        guard input.isSwiftSymbol else {
-            return nil
-        }
-        return try? demangleAsNode(input).print(using: .default)
-    }
-
-    private static func simplify(_ demangled: String) -> String {
-        guard let firstDot = demangled.firstIndex(of: ".") else {
-            return demangled
-        }
-        let moduleName = demangled[..<firstDot]
-        guard moduleName.range(of: #"^[A-Za-z_][A-Za-z0-9_]*$"#, options: .regularExpression) != nil else {
-            return demangled
-        }
-        return String(demangled[demangled.index(after: firstDot)...])
+    private static func demangle(_ input: String, options: DemangleOptions) -> String? {
+        return try? demangleAsNode(input).print(using: options)
     }
 
     /// 这里返回的结果会尽可能地短，去除了很多信息
@@ -36,7 +22,7 @@ public class LKSwiftDemangler: NSObject {
         if let cachedResult = simpleCache[input] {
             return cachedResult
         }
-        let result = demangle(input).map(simplify) ?? input
+        let result = demangle(input, options: .interfaceType) ?? input
         simpleCache[input] = result
         return result
     }
@@ -46,7 +32,7 @@ public class LKSwiftDemangler: NSObject {
         if let cachedResult = completedCache[input] {
             return cachedResult
         }
-        let result = demangle(input) ?? input
+        let result = demangle(input, options: .default) ?? input
         completedCache[input] = result
         return result
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "d7874ad4af3244e162af52c5a67777bc71b99759e978f6f2c918894c457f0575",
+  "originHash" : "5583f0a13b7cb51bcd3bc0f7069181175880f916bf772fb831e3a7cd0bcb4b0f",
   "pins" : [
+    {
+      "identity" : "frameworktoolbox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Mx-Iris/FrameworkToolbox",
+      "state" : {
+        "revision" : "342b9846c6333700be6f0603b1b827cc90df87c5",
+        "version" : "0.5.1"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,24 @@
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-demangling",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-demangling.git",
+      "state" : {
+        "revision" : "6b05bc6013eb695975ecdcdadea2e5b0ad6ca01e",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "5aa3374f22c1ed4936019242820e4c6e9b11fbb9da009f7d6963fbcf26d5cfae",
+  "originHash" : "5583f0a13b7cb51bcd3bc0f7069181175880f916bf772fb831e3a7cd0bcb4b0f",
   "pins" : [
+    {
+      "identity" : "frameworktoolbox",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Mx-Iris/FrameworkToolbox",
+      "state" : {
+        "revision" : "342b9846c6333700be6f0603b1b827cc90df87c5",
+        "version" : "0.5.1"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,24 @@
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-demangling",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-demangling.git",
+      "state" : {
+        "revision" : "6b05bc6013eb695975ecdcdadea2e5b0ad6ca01e",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "5583f0a13b7cb51bcd3bc0f7069181175880f916bf772fb831e3a7cd0bcb4b0f",
+  "originHash" : "5aa3374f22c1ed4936019242820e4c6e9b11fbb9da009f7d6963fbcf26d5cfae",
   "pins" : [
-    {
-      "identity" : "frameworktoolbox",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Mx-Iris/FrameworkToolbox",
-      "state" : {
-        "revision" : "342b9846c6333700be6f0603b1b827cc90df87c5",
-        "version" : "0.5.1"
-      }
-    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -17,24 +8,6 @@
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-demangling",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-demangling.git",
-      "state" : {
-        "revision" : "6b05bc6013eb695975ecdcdadea2e5b0ad6ca01e",
-        "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
-      "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ swift build -c debug --product lookinside
 
 ```bash
 bash Scripts/sync-derived-source.sh
-xcodebuild -project LookInside.xcodeproj -scheme LookInside -configuration Debug -derivedDataPath /tmp/LookInsideDerivedData CODE_SIGNING_ALLOWED=NO build
+xcodebuild -skipMacroValidation -project LookInside.xcodeproj -scheme LookInside -configuration Debug -derivedDataPath /tmp/LookInsideDerivedData CODE_SIGNING_ALLOWED=NO build
 ```
 
 The sync step refreshes the app's mirrored shared sources from [`Sources/`](Sources/) into [`LookInside/DerivedSource`](LookInside/DerivedSource).

--- a/Scripts/build-and-release.sh
+++ b/Scripts/build-and-release.sh
@@ -215,6 +215,7 @@ create_archive() {
         --signing-identity "$identity"
 
     xcodebuild \
+        -skipMacroValidation \
         -project "$PROJECT_FILE" \
         -scheme "$SCHEME" \
         -configuration "$CONFIGURATION" \

--- a/Scripts/build-release-from-tag.sh
+++ b/Scripts/build-release-from-tag.sh
@@ -276,6 +276,7 @@ archive_app_unsigned() {
 
     log "Archiving app without Xcode signing"
     xcodebuild \
+        -skipMacroValidation \
         -project "$PROJECT_FILE" \
         -scheme "$SCHEME" \
         -configuration "$CONFIGURATION" \

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -48,6 +48,7 @@ run_xcode_build() {
     run_command \
         "xcodebuild scheme=$scheme configuration=$configuration" \
         xcodebuild \
+        -skipMacroValidation \
         -project LookInside.xcodeproj \
         -scheme "$scheme" \
         -configuration "$configuration" \


### PR DESCRIPTION
## Summary
- replace the direct Swift runtime demangle call with Iris's Demangling package
- link the Demangling SwiftPM product into the LookInside app target and pin transitive dependencies
- add -skipMacroValidation to command-line Xcode build paths because FrameworkToolbox uses macros

## Validation
- bash Scripts/test.sh