### PR TITLE
Gate SwiftUI Support on auth helper activation state

### DIFF
--- a/LookInside/AppDelegate.m
+++ b/LookInside/AppDelegate.m
@@ -50,10 +50,35 @@
     if (!self.launchedToOpenFile) {
         [[LKNavigationManager sharedInstance] showLaunch];
     }
-    
+
+    [self _lk_installActivationStateObserverExample];
+
 #ifdef DEBUG
     [self _runTests];
 #endif
+}
+
+- (void)_lk_installActivationStateObserverExample {
+    LKSwiftUISupportGatekeeper *gatekeeper = [LKSwiftUISupportGatekeeper sharedInstance];
+    NSLog(@"[LK-Activation] initial state=%ld (polling every 5s; waits for auth server)",
+          (long)gatekeeper.activationState);
+
+    [NSNotificationCenter.defaultCenter
+        addObserver:self
+           selector:@selector(_lk_activationStateDidChange:)
+               name:LKSwiftUISupportGatekeeper.activationStateDidChangeNotificationName
+             object:nil];
+}
+
+- (void)_lk_activationStateDidChange:(NSNotification *)note {
+    NSNumber *state = note.userInfo[@"activationState"];
+    NSString *label;
+    switch ((LKSwiftUISupportActivationState)state.integerValue) {
+        case LKSwiftUISupportActivationStateUnknown:      label = @"unknown"; break;
+        case LKSwiftUISupportActivationStateNotActivated: label = @"notActivated"; break;
+        case LKSwiftUISupportActivationStateActivated:    label = @"activated"; break;
+    }
+    NSLog(@"[LK-Activation] state changed -> %@ (raw=%@)", label, state);
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {

--- a/LookInside/AppDelegate.m
+++ b/LookInside/AppDelegate.m
@@ -45,8 +45,7 @@
     }];
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {    
-    [[LKSwiftUISupportGatekeeper sharedInstance] preloadRuntime];
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     [LKConnectionManager sharedInstance];
     if (!self.launchedToOpenFile) {
         [[LKNavigationManager sharedInstance] showLaunch];

--- a/LookInside/Localizable.xcstrings
+++ b/LookInside/Localizable.xcstrings
@@ -257,6 +257,38 @@
         }
       }
     },
+    "Checking for updates…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Checking for updates…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查更新…"
+          }
+        }
+      }
+    },
+    "Checking LookInside Auth Server" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Checking LookInside Auth Server"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查 LookInside 授权服务器"
+          }
+        }
+      }
+    },
     "Click the screenshot below to Change App" : {
       "localizations" : {
         "en" : {
@@ -513,6 +545,22 @@
         }
       }
     },
+    "ditto exited with status %d." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "ditto exited with status %d."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ditto 以状态码 %d 退出。"
+          }
+        }
+      }
+    },
     "Don't remind me again" : {
       "localizations" : {
         "en" : {
@@ -557,6 +605,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "双击"
+          }
+        }
+      }
+    },
+    "Downloading…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Downloading…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在下载…"
+          }
+        }
+      }
+    },
+    "Empty download payload." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty download payload."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载内容为空。"
+          }
+        }
+      }
+    },
+    "Executable not found at %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Executable not found at %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %@ 未找到可执行文件"
           }
         }
       }
@@ -609,6 +705,22 @@
         }
       }
     },
+    "Expected %1$@, got %2$@." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Expected %1$@, got %2$@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "期望 %1$@，实际 %2$@。"
+          }
+        }
+      }
+    },
     "Export screenshot…" : {
       "localizations" : {
         "en" : {
@@ -621,6 +733,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导出截图…"
+          }
+        }
+      }
+    },
+    "Extracting…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Extracting…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在解压…"
           }
         }
       }
@@ -658,6 +786,38 @@
         }
       }
     },
+    "Failed to download LookInside Auth Server.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to download LookInside Auth Server.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载 LookInside 授权服务器失败。\n%@"
+          }
+        }
+      }
+    },
+    "Failed to extract LookInside Auth Server.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to extract LookInside Auth Server.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解压 LookInside 授权服务器失败。\n%@"
+          }
+        }
+      }
+    },
     "Failed to get target object in iOS app" : {
       "localizations" : {
         "en" : {
@@ -670,6 +830,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法在 iOS App 中获取目标对象"
+          }
+        }
+      }
+    },
+    "Failed to install LookInside Auth Server.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to install LookInside Auth Server.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安装 LookInside 授权服务器失败。\n%@"
           }
         }
       }
@@ -702,6 +878,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查找相关方法失败："
+          }
+        }
+      }
+    },
+    "Failed to verify LookInside Auth Server download.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to verify LookInside Auth Server download.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "验证 LookInside 授权服务器下载失败。\n%@"
           }
         }
       }
@@ -782,6 +974,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "筛选"
+          }
+        }
+      }
+    },
+    "Finalizing…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Finalizing…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成…"
           }
         }
       }
@@ -1022,6 +1230,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "继承自"
+          }
+        }
+      }
+    },
+    "Installation was cancelled." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Installation was cancelled."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安装已取消。"
+          }
+        }
+      }
+    },
+    "Installing LookInside Auth Server" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Installing LookInside Auth Server"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在安装 LookInside 授权服务器"
+          }
+        }
+      }
+    },
+    "Installing…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Installing…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在安装…"
           }
         }
       }
@@ -1270,6 +1526,182 @@
         }
       }
     },
+    "LookInside Auth Server connection failed.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server connection failed.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器连接失败。\n%@"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server could not be launched.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server could not be launched.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器无法启动。\n%@"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server did not respond after launch.\nSocket path:\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server did not respond after launch.\nSocket path:\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器启动后无响应。\nSocket 路径：\n%@"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server is not installed.\nExpected executable:\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server is not installed.\nExpected executable:\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器未安装。\n期望的可执行文件：\n%@"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server is signed by a different team.\nExpected: %1$@\nFound: %2$@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server is signed by a different team.\nExpected: %1$@\nFound: %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器的签名团队不匹配。\n期望：%1$@\n实际：%2$@"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server protocol is incompatible.\nApp expects v%1$ld, helper provides v%2$ld." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server protocol is incompatible.\nApp expects v%1$ld, helper provides v%2$ld."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器协议不兼容。\nApp 期望 v%1$ld，辅助程序提供 v%2$ld。"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server Required" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server Required"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 LookInside 授权服务器"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server returned %1$@.\n%2$@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server returned %1$@.\n%2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器返回 %1$@。\n%2$@"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server returned an unreadable response.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server returned an unreadable response.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器返回了无法读取的响应。\n%@"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server socket path is too long for a Unix domain socket.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server socket path is too long for a Unix domain socket.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器 Socket 路径超过 Unix 域套接字长度限制。\n%@"
+          }
+        }
+      }
+    },
+    "LookInside Auth Server version mismatch.\nExpected: %1$@\nFound: %2$@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "LookInside Auth Server version mismatch.\nExpected: %1$@\nFound: %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LookInside 授权服务器版本不匹配。\n期望：%1$@\n实际：%2$@"
+          }
+        }
+      }
+    },
     "LookInside doesn't support invoking methods with arguments yet." : {
       "localizations" : {
         "zh-Hans" : {
@@ -1430,6 +1862,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尚未返回对象"
+          }
+        }
+      }
+    },
+    "No response received." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No response received."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未收到响应。"
           }
         }
       }
@@ -1696,6 +2144,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "偏好设置"
+          }
+        }
+      }
+    },
+    "Preparing…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preparing…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备…"
           }
         }
       }
@@ -2136,6 +2600,22 @@
         }
       }
     },
+    "The downloaded archive did not contain a LookInside Auth Server bundle." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The downloaded archive did not contain a LookInside Auth Server bundle."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载的压缩包中未包含 LookInside 授权服务器。"
+          }
+        }
+      }
+    },
     "The feature is not available in current mode." : {
       "localizations" : {
         "en" : {
@@ -2260,6 +2740,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作失败，因为与 iOS App 的连接已断开。"
+          }
+        }
+      }
+    },
+    "The release checksum file is malformed." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The release checksum file is malformed."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校验和文件格式错误。"
           }
         }
       }
@@ -2418,6 +2914,38 @@
         }
       }
     },
+    "Unable to read the code signature of LookInside Auth Server.\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to read the code signature of LookInside Auth Server.\n%@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法读取 LookInside 授权服务器的代码签名。\n%@"
+          }
+        }
+      }
+    },
+    "Unknown download failure." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown download failure."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知的下载失败。"
+          }
+        }
+      }
+    },
     "Updating screenshots… %@ / %@" : {
       "localizations" : {
         "en" : {
@@ -2430,6 +2958,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在更新截图… %1$@ / %2$@"
+          }
+        }
+      }
+    },
+    "Verifying code signature…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Verifying code signature…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在验证代码签名…"
           }
         }
       }
@@ -2546,518 +3090,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "缩放"
-          }
-        }
-      }
-    },
-    "Downloading…" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Downloading…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在下载…"
-          }
-        }
-      }
-    },
-    "Empty download payload." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Empty download payload."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载内容为空。"
-          }
-        }
-      }
-    },
-    "Expected %1$@, got %2$@." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Expected %1$@, got %2$@."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "期望 %1$@，实际 %2$@。"
-          }
-        }
-      }
-    },
-    "Extracting…" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Extracting…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在解压…"
-          }
-        }
-      }
-    },
-    "Failed to download LookInside Auth Server.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to download LookInside Auth Server.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载 LookInside 授权服务器失败。\n%@"
-          }
-        }
-      }
-    },
-    "Failed to extract LookInside Auth Server.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to extract LookInside Auth Server.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "解压 LookInside 授权服务器失败。\n%@"
-          }
-        }
-      }
-    },
-    "Failed to install LookInside Auth Server.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to install LookInside Auth Server.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安装 LookInside 授权服务器失败。\n%@"
-          }
-        }
-      }
-    },
-    "Failed to verify LookInside Auth Server download.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to verify LookInside Auth Server download.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "验证 LookInside 授权服务器下载失败。\n%@"
-          }
-        }
-      }
-    },
-    "Finalizing…" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Finalizing…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在完成…"
-          }
-        }
-      }
-    },
-    "Installing…" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Installing…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在安装…"
-          }
-        }
-      }
-    },
-    "Installing LookInside Auth Server" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Installing LookInside Auth Server"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在安装 LookInside 授权服务器"
-          }
-        }
-      }
-    },
-    "Installation was cancelled." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Installation was cancelled."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安装已取消。"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server connection failed.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server connection failed.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器连接失败。\n%@"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server could not be launched.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server could not be launched.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器无法启动。\n%@"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server did not respond after launch.\nSocket path:\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server did not respond after launch.\nSocket path:\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器启动后无响应。\nSocket 路径：\n%@"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server is not installed.\nExpected executable:\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server is not installed.\nExpected executable:\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器未安装。\n期望的可执行文件：\n%@"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server protocol is incompatible.\nApp expects v%1$ld, helper provides v%2$ld." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server protocol is incompatible.\nApp expects v%1$ld, helper provides v%2$ld."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器协议不兼容。\nApp 期望 v%1$ld，辅助程序提供 v%2$ld。"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server Required" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server Required"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "需要 LookInside 授权服务器"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server returned %1$@.\n%2$@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server returned %1$@.\n%2$@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器返回 %1$@。\n%2$@"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server returned an unreadable response.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server returned an unreadable response.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器返回了无法读取的响应。\n%@"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server is signed by a different team.\nExpected: %1$@\nFound: %2$@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server is signed by a different team.\nExpected: %1$@\nFound: %2$@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器的签名团队不匹配。\n期望：%1$@\n实际：%2$@"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server socket path is too long for a Unix domain socket.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server socket path is too long for a Unix domain socket.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器 Socket 路径超过 Unix 域套接字长度限制。\n%@"
-          }
-        }
-      }
-    },
-    "LookInside Auth Server version mismatch.\nExpected: %1$@\nFound: %2$@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "LookInside Auth Server version mismatch.\nExpected: %1$@\nFound: %2$@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LookInside 授权服务器版本不匹配。\n期望：%1$@\n实际：%2$@"
-          }
-        }
-      }
-    },
-    "No response received." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No response received."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未收到响应。"
-          }
-        }
-      }
-    },
-    "Preparing…" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Preparing…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在准备…"
-          }
-        }
-      }
-    },
-    "The downloaded archive did not contain a LookInside Auth Server bundle." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The downloaded archive did not contain a LookInside Auth Server bundle."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载的压缩包中未包含 LookInside 授权服务器。"
-          }
-        }
-      }
-    },
-    "The release checksum file is malformed." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The release checksum file is malformed."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "校验和文件格式错误。"
-          }
-        }
-      }
-    },
-    "Unable to read the code signature of LookInside Auth Server.\n%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Unable to read the code signature of LookInside Auth Server.\n%@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法读取 LookInside 授权服务器的代码签名。\n%@"
-          }
-        }
-      }
-    },
-    "Unknown download failure." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown download failure."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未知的下载失败。"
-          }
-        }
-      }
-    },
-    "Verifying code signature…" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Verifying code signature…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在验证代码签名…"
-          }
-        }
-      }
-    },
-    "Executable not found at %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Executable not found at %@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 %@ 未找到可执行文件"
-          }
-        }
-      }
-    },
-    "ditto exited with status %d." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "ditto exited with status %d."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ditto 以状态码 %d 退出。"
           }
         }
       }

--- a/LookInside/Manager/LKAppMenuManager.m
+++ b/LookInside/Manager/LKAppMenuManager.m
@@ -18,6 +18,12 @@ static NSUInteger const kTag_CheckUpdates = 13;
 static NSUInteger const kTag_ActivateSwiftUISupport = 14;
 static NSUInteger const kTag_SwiftUISupportLicense = 15;
 static NSUInteger const kTag_RefreshSwiftUISupportLicense = 16;
+static NSUInteger const kTag_PurchaseSwiftUISupport = 17;
+static NSUInteger const kTag_SwiftUISupportCustomerSupport = 18;
+static NSUInteger const kTag_SwiftUISupportSubmenu = 19;
+
+static NSString *const kSwiftUISupportPurchaseURL = @"https://example.com/";
+static NSString *const kSwiftUISupportCustomerSupportURL = @"https://example.com/";
 
 static NSUInteger const kTag_Reload = 21;
 static NSUInteger const kTag_Dimension = 22;
@@ -184,16 +190,55 @@ static NSMenuItem *LKSubmenuItem(NSString *title, NSMenu *submenu, NSInteger tag
 }
 
 - (NSMenu *)_buildSwiftUIPluginSubmenu {
-    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"SwiftUI"];
-    [menu addItem:LKMenuItem(@"Activate SwiftUI Support…", nil, @"", 0, kTag_ActivateSwiftUISupport)];
-    [menu addItem:LKMenuItem(@"SwiftUI Support License…", nil, @"", 0, kTag_SwiftUISupportLicense)];
-    [menu addItem:LKMenuItem(@"Refresh License Status", nil, @"", 0, kTag_RefreshSwiftUISupportLicense)];
+    NSMenu *menu = [[NSMenu alloc] initWithTitle:@"SwiftUI Support"];
+    [self _populateSwiftUIPluginSubmenu:menu];
     return menu;
+}
+
+- (void)_populateSwiftUIPluginSubmenu:(NSMenu *)menu {
+    [menu removeAllItems];
+
+    LKSwiftUISupportActivationState state = [LKSwiftUISupportGatekeeper sharedInstance].activationState;
+
+    if (state == LKSwiftUISupportActivationStateActivated) {
+        [menu addItem:LKMenuItem(@"SwiftUI Support License…", nil, @"", 0, kTag_SwiftUISupportLicense)];
+        [menu addItem:LKMenuItem(@"Refresh License Status", nil, @"", 0, kTag_RefreshSwiftUISupportLicense)];
+        [menu addItem:[NSMenuItem separatorItem]];
+        [menu addItem:LKMenuItem(@"Customer Support…", nil, @"", 0, kTag_SwiftUISupportCustomerSupport)];
+    } else {
+        [menu addItem:LKMenuItem(@"Activate SwiftUI Support…", nil, @"", 0, kTag_ActivateSwiftUISupport)];
+        [menu addItem:[NSMenuItem separatorItem]];
+        [menu addItem:LKMenuItem(@"Purchase…", nil, @"", 0, kTag_PurchaseSwiftUISupport)];
+    }
+
+    [self _wireSwiftUIPluginSubmenuActions:menu];
+}
+
+- (void)_wireSwiftUIPluginSubmenuActions:(NSMenu *)menu {
+    NSMenuItem *activateItem = [menu itemWithTag:kTag_ActivateSwiftUISupport];
+    activateItem.target = self;
+    activateItem.action = @selector(_handleActivateSwiftUISupport);
+
+    NSMenuItem *licenseItem = [menu itemWithTag:kTag_SwiftUISupportLicense];
+    licenseItem.target = self;
+    licenseItem.action = @selector(_handleSwiftUISupportLicense);
+
+    NSMenuItem *refreshItem = [menu itemWithTag:kTag_RefreshSwiftUISupportLicense];
+    refreshItem.target = self;
+    refreshItem.action = @selector(_handleRefreshSwiftUISupportLicense);
+
+    NSMenuItem *purchaseItem = [menu itemWithTag:kTag_PurchaseSwiftUISupport];
+    purchaseItem.target = self;
+    purchaseItem.action = @selector(_handlePurchaseSwiftUISupport);
+
+    NSMenuItem *customerSupportItem = [menu itemWithTag:kTag_SwiftUISupportCustomerSupport];
+    customerSupportItem.target = self;
+    customerSupportItem.action = @selector(_handleSwiftUISupportCustomerSupport);
 }
 
 - (NSMenu *)_buildPluginsMenu {
     NSMenu *menu = [[NSMenu alloc] initWithTitle:@"Plugins"];
-    [menu addItem:LKSubmenuItem(@"SwiftUI", [self _buildSwiftUIPluginSubmenu], 0)];
+    [menu addItem:LKSubmenuItem(@"SwiftUI Support", [self _buildSwiftUIPluginSubmenu], kTag_SwiftUISupportSubmenu)];
     return menu;
 }
 
@@ -279,18 +324,8 @@ static NSMenuItem *LKSubmenuItem(NSString *title, NSMenu *submenu, NSInteger tag
     menu_plugins.autoenablesItems = NO;
     NSMenu *menu_plugins_swiftUI = [menu_plugins itemAtIndex:0].submenu;
     menu_plugins_swiftUI.autoenablesItems = NO;
-
-    NSMenuItem *menuItem_activateSwiftUISupport = [menu_plugins_swiftUI itemWithTag:kTag_ActivateSwiftUISupport];
-    menuItem_activateSwiftUISupport.target = self;
-    menuItem_activateSwiftUISupport.action = @selector(_handleActivateSwiftUISupport);
-
-    NSMenuItem *menuItem_swiftUISupportLicense = [menu_plugins_swiftUI itemWithTag:kTag_SwiftUISupportLicense];
-    menuItem_swiftUISupportLicense.target = self;
-    menuItem_swiftUISupportLicense.action = @selector(_handleSwiftUISupportLicense);
-
-    NSMenuItem *menuItem_refreshSwiftUISupportLicense = [menu_plugins_swiftUI itemWithTag:kTag_RefreshSwiftUISupportLicense];
-    menuItem_refreshSwiftUISupportLicense.target = self;
-    menuItem_refreshSwiftUISupportLicense.action = @selector(_handleRefreshSwiftUISupportLicense);
+    menu_plugins_swiftUI.delegate = self;
+    [self _wireSwiftUIPluginSubmenuActions:menu_plugins_swiftUI];
 
     NSMenu *menu_help = [menu itemAtIndex:6].submenu;
     menu_help.autoenablesItems = YES;
@@ -329,6 +364,12 @@ static NSMenuItem *LKSubmenuItem(NSString *title, NSMenu *submenu, NSInteger tag
 - (void)menuNeedsUpdate:(NSMenu *)menu {
     if (menu == self.recentDocumentsMenu) {
         [self _reloadRecentDocumentsMenu];
+        return;
+    }
+
+    if ([menu.title isEqualToString:@"SwiftUI Support"]) {
+        [[LKSwiftUISupportGatekeeper sharedInstance] refreshActivationStateInBackground];
+        [self _populateSwiftUIPluginSubmenu:menu];
         return;
     }
 
@@ -414,6 +455,20 @@ static NSMenuItem *LKSubmenuItem(NSString *title, NSMenu *submenu, NSInteger tag
 
 - (void)_handleRefreshSwiftUISupportLicense {
     [[LKSwiftUISupportGatekeeper sharedInstance] refreshLicenseStatus];
+}
+
+- (void)_handlePurchaseSwiftUISupport {
+    NSURL *url = [NSURL URLWithString:kSwiftUISupportPurchaseURL];
+    if (url) {
+        [[NSWorkspace sharedWorkspace] openURL:url];
+    }
+}
+
+- (void)_handleSwiftUISupportCustomerSupport {
+    NSURL *url = [NSURL URLWithString:kSwiftUISupportCustomerSupportURL];
+    if (url) {
+        [[NSWorkspace sharedWorkspace] openURL:url];
+    }
 }
 
 - (void)_handleShowGitHub {

--- a/LookInside/SwiftUISupport/LKSwiftUISupportGatekeeper.swift
+++ b/LookInside/SwiftUISupport/LKSwiftUISupportGatekeeper.swift
@@ -7,9 +7,23 @@ private enum LKSwiftUISupportAuthServerConstants {
 
     static let helperPathEnvironmentKey = "LOOKINSIDE_AUTH_SERVER_PATH"
     static let helperSocketPathEnvironmentKey = "LOOKINSIDE_AUTH_SERVER_SOCKET_PATH"
+    static let helperClientProcessIDEnvironmentKey = "LOOKINSIDE_AUTH_SERVER_CLIENT_PID"
 
-    static let helperLaunchTimeout: TimeInterval = 8
+    static let firstLaunchHealthTimeout: TimeInterval = 1.0
+    static let relaunchHealthTimeout: TimeInterval = 3.0
+    static let helperHealthPollInterval: useconds_t = 100_000
     static let helperShutdownTimeout: TimeInterval = 3
+}
+
+private enum LKSwiftUISupportHelperPresence {
+    case notDetermined
+    case spawned
+}
+
+@objc public enum LKSwiftUISupportActivationState: Int {
+    case unknown
+    case notActivated
+    case activated
 }
 
 private struct LKSwiftUISupportAuthServerInstallation {
@@ -18,6 +32,14 @@ private struct LKSwiftUISupportAuthServerInstallation {
 }
 
 private struct LKSwiftUISupportEmptyPayload: Codable {}
+
+private struct LKSwiftUISupportClientProcessPayload: Encodable {
+    let lookInsideProcessID: Int32
+
+    private enum CodingKeys: String, CodingKey {
+        case lookInsideProcessID = "lookinside_pid"
+    }
+}
 
 private struct LKSwiftUISupportAuthServerRequestEnvelope<Payload: Encodable>: Encodable {
     let protocolVersion: Int
@@ -125,43 +147,78 @@ private final class LKSwiftUISupportAuthServerBridge {
     private let lock = NSLock()
     private var launchedProcess: Process?
     private var lastPresentedErrorDescription: String?
+    private var helperPresence: LKSwiftUISupportHelperPresence = .notDetermined
+    private var activationState: LKSwiftUISupportActivationState = .unknown
+    private var activationStateRefreshInFlight = false
 
-    func preloadRuntime() {
-        guard LKSwiftUISupportInstallerLayout.isInstalled else {
+    var currentActivationState: LKSwiftUISupportActivationState {
+        lock.withLock { activationState }
+    }
+
+    private func recordDecision(_ decision: LKSwiftUISupportAuthServerAccessDecisionPayload.Decision) {
+        let state: LKSwiftUISupportActivationState
+        switch decision {
+        case .allow, .allowWithWarning:
+            state = .activated
+        case .block:
+            state = .notActivated
+        }
+        lock.withLock { activationState = state }
+    }
+
+    func refreshActivationStateInBackground() {
+        let shouldStart: Bool = lock.withLock {
+            if activationStateRefreshInFlight {
+                return false
+            }
+            activationStateRefreshInFlight = true
+            return true
+        }
+        guard shouldStart else {
             return
         }
-        do {
-            let installation = try resolveInstallation()
-            _ = try ensureServerAvailable(using: installation)
-        } catch {
-            LKSwiftUISupportLogger.authServer.error(
-                "preload failed: \(error.localizedDescription, privacy: .public)"
-            )
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            defer {
+                self?.lock.withLock { self?.activationStateRefreshInFlight = false }
+            }
+            guard let self else { return }
+            guard let installation = try? self.resolveInstallation() else {
+                return
+            }
+            do {
+                let response = try self.sendRequest(
+                    method: "license.check_access",
+                    payload: LKSwiftUISupportEmptyPayload(),
+                    installation: installation,
+                    responseType: LKSwiftUISupportAuthServerAccessDecisionPayload.self
+                )
+                if let payload = response.payload {
+                    self.recordDecision(payload.decision)
+                }
+            } catch {
+                LKSwiftUISupportLogger.authServer.info(
+                    "activation state refresh failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
         }
     }
 
     func shutdownRuntime() {
-        let process = lock.withLock {
-            launchedProcess
-        }
-
         guard let installation = try? resolveInstallation() else {
             return
         }
 
-        if process != nil {
-            do {
-                _ = try sendRequest(
-                    method: "server.shutdown",
-                    payload: LKSwiftUISupportEmptyPayload(),
-                    installation: installation,
-                    responseType: LKSwiftUISupportEmptyPayload.self
-                )
-            } catch {
-                LKSwiftUISupportLogger.authServer.error(
-                    "shutdown request failed: \(error.localizedDescription, privacy: .public)"
-                )
-            }
+        do {
+            _ = try sendRequest(
+                method: "server.shutdown",
+                payload: LKSwiftUISupportEmptyPayload(),
+                installation: installation,
+                responseType: LKSwiftUISupportEmptyPayload.self
+            )
+        } catch {
+            LKSwiftUISupportLogger.authServer.error(
+                "shutdown request failed: \(error.localizedDescription, privacy: .public)"
+            )
         }
 
         unlink(installation.socketURL.path + ".lock")
@@ -183,6 +240,7 @@ private final class LKSwiftUISupportAuthServerBridge {
                 launchedProcess.terminate()
             }
             self.launchedProcess = nil
+            self.helperPresence = .notDetermined
         }
     }
 
@@ -202,7 +260,10 @@ private final class LKSwiftUISupportAuthServerBridge {
             unlink(installation.socketURL.path + ".lock")
             unlink(installation.socketURL.path)
         }
-        lock.withLock { self.launchedProcess = nil }
+        lock.withLock {
+            self.launchedProcess = nil
+            self.helperPresence = .notDetermined
+        }
     }
 
     private func shouldTriggerRefresh(for error: Error) -> Bool {
@@ -222,7 +283,13 @@ private final class LKSwiftUISupportAuthServerBridge {
     }
 
     func showActivationWindow(from window: NSWindow?) {
-        performVoidRequest(method: "ui.show_activation", from: window)
+        performVoidRequest(
+            method: "ui.show_activation",
+            payload: LKSwiftUISupportClientProcessPayload(
+                lookInsideProcessID: ProcessInfo.processInfo.processIdentifier
+            ),
+            from: window
+        )
     }
 
     func showLicenseWindow(from window: NSWindow?) {
@@ -243,6 +310,7 @@ private final class LKSwiftUISupportAuthServerBridge {
                 }
                 return payload
             }
+            recordDecision(payload.decision)
             presentAccessAlert(title: payload.title, detail: payload.message, window: window)
         } catch {
             presentRuntimeAlert(title: NSLocalizedString("LookInside Auth Server Required", comment: ""), detail: error.localizedDescription, window: window)
@@ -264,6 +332,8 @@ private final class LKSwiftUISupportAuthServerBridge {
                 return payload
             }
 
+            recordDecision(payload.decision)
+
             switch payload.decision {
             case .allow:
                 return true
@@ -281,11 +351,23 @@ private final class LKSwiftUISupportAuthServerBridge {
     }
 
     private func performVoidRequest(method: String, from window: NSWindow?) {
+        performVoidRequest(
+            method: method,
+            payload: LKSwiftUISupportEmptyPayload(),
+            from: window
+        )
+    }
+
+    private func performVoidRequest<RequestPayload: Encodable>(
+        method: String,
+        payload: RequestPayload,
+        from window: NSWindow?
+    ) {
         do {
             try runWithAutoRefresh(window: window) { installation in
                 _ = try self.sendRequest(
                     method: method,
-                    payload: LKSwiftUISupportEmptyPayload(),
+                    payload: payload,
                     installation: installation,
                     responseType: LKSwiftUISupportEmptyPayload.self
                 )
@@ -325,66 +407,85 @@ private final class LKSwiftUISupportAuthServerBridge {
     private func ensureServerAvailable(
         using installation: LKSwiftUISupportAuthServerInstallation
     ) throws -> LKSwiftUISupportAuthServerInstallation {
-        do {
-            let response = try sendRequest(
-                method: "health.ping",
-                payload: LKSwiftUISupportEmptyPayload(),
-                installation: installation,
-                responseType: LKSwiftUISupportAuthServerHealthPayload.self
-            )
-            guard let payload = response.payload else {
-                throw LKSwiftUISupportAuthServerError.invalidResponse("Missing health payload.")
-            }
-            guard payload.protocolVersion == LKSwiftUISupportAuthServerConstants.supportedProtocolVersion else {
-                throw LKSwiftUISupportAuthServerError.incompatibleProtocol(
-                    expected: LKSwiftUISupportAuthServerConstants.supportedProtocolVersion,
-                    found: payload.protocolVersion
-                )
-            }
-            try enforceVersionMatch(payload: payload)
-            return installation
-        } catch LKSwiftUISupportAuthServerError.helperVersionMismatch(let expected, let found) {
-            throw LKSwiftUISupportAuthServerError.helperVersionMismatch(expected: expected, found: found)
-        } catch {
+        let presence = lock.withLock { helperPresence }
+
+        if presence == .notDetermined {
             try launchHelperIfNeeded(for: installation)
-            return try waitForHealthyServer(using: installation)
+            try waitForHealthyServer(
+                using: installation,
+                timeout: LKSwiftUISupportAuthServerConstants.firstLaunchHealthTimeout
+            )
+            lock.withLock { helperPresence = .spawned }
+            return installation
         }
-    }
 
-    private func waitForHealthyServer(
-        using installation: LKSwiftUISupportAuthServerInstallation
-    ) throws -> LKSwiftUISupportAuthServerInstallation {
-        let deadline = Date().addingTimeInterval(LKSwiftUISupportAuthServerConstants.helperLaunchTimeout)
-        var lastError: Error?
-
-        while Date() < deadline {
+        for attempt in 0 ..< 2 {
             do {
-                let response = try sendRequest(
-                    method: "health.ping",
-                    payload: LKSwiftUISupportEmptyPayload(),
-                    installation: installation,
-                    responseType: LKSwiftUISupportAuthServerHealthPayload.self
-                )
-                guard let payload = response.payload else {
-                    throw LKSwiftUISupportAuthServerError.invalidResponse("Missing health payload.")
-                }
-                guard payload.protocolVersion == LKSwiftUISupportAuthServerConstants.supportedProtocolVersion else {
-                    throw LKSwiftUISupportAuthServerError.incompatibleProtocol(
-                        expected: LKSwiftUISupportAuthServerConstants.supportedProtocolVersion,
-                        found: payload.protocolVersion
-                    )
-                }
-                try enforceVersionMatch(payload: payload)
+                try performHealthPing(using: installation)
                 return installation
             } catch let error as LKSwiftUISupportAuthServerError {
                 if case .helperVersionMismatch = error {
                     throw error
                 }
+                LKSwiftUISupportLogger.authServer.info(
+                    "health probe attempt \(attempt + 1) failed: \(error.localizedDescription, privacy: .public)"
+                )
+            } catch {
+                LKSwiftUISupportLogger.authServer.info(
+                    "health probe attempt \(attempt + 1) failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+
+        try launchHelperIfNeeded(for: installation)
+        try waitForHealthyServer(
+            using: installation,
+            timeout: LKSwiftUISupportAuthServerConstants.relaunchHealthTimeout
+        )
+        return installation
+    }
+
+    private func performHealthPing(
+        using installation: LKSwiftUISupportAuthServerInstallation
+    ) throws {
+        let response = try sendRequest(
+            method: "health.ping",
+            payload: LKSwiftUISupportEmptyPayload(),
+            installation: installation,
+            responseType: LKSwiftUISupportAuthServerHealthPayload.self
+        )
+        guard let payload = response.payload else {
+            throw LKSwiftUISupportAuthServerError.invalidResponse("Missing health payload.")
+        }
+        guard payload.protocolVersion == LKSwiftUISupportAuthServerConstants.supportedProtocolVersion else {
+            throw LKSwiftUISupportAuthServerError.incompatibleProtocol(
+                expected: LKSwiftUISupportAuthServerConstants.supportedProtocolVersion,
+                found: payload.protocolVersion
+            )
+        }
+        try enforceVersionMatch(payload: payload)
+    }
+
+    private func waitForHealthyServer(
+        using installation: LKSwiftUISupportAuthServerInstallation,
+        timeout: TimeInterval
+    ) throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastError: Error?
+
+        while Date() < deadline {
+            do {
+                try performHealthPing(using: installation)
+                return
+            } catch let error as LKSwiftUISupportAuthServerError {
+                if case .helperVersionMismatch = error {
+                    throw error
+                }
                 lastError = error
-                usleep(100_000)
+                usleep(LKSwiftUISupportAuthServerConstants.helperHealthPollInterval)
             } catch {
                 lastError = error
-                usleep(100_000)
+                usleep(LKSwiftUISupportAuthServerConstants.helperHealthPollInterval)
             }
         }
 
@@ -449,14 +550,20 @@ private final class LKSwiftUISupportAuthServerBridge {
 
             let process = Process()
             process.executableURL = installation.executableURL
-            process.arguments = ["--socket-path", installation.socketURL.path]
+            let clientProcessID = ProcessInfo.processInfo.processIdentifier
+            process.arguments = [
+                "--socket-path", installation.socketURL.path,
+                "--lookinside-pid", "\(clientProcessID)"
+            ]
 
             var environment = ProcessInfo.processInfo.environment
             environment[LKSwiftUISupportAuthServerConstants.helperSocketPathEnvironmentKey] = installation.socketURL.path
+            environment[LKSwiftUISupportAuthServerConstants.helperClientProcessIDEnvironmentKey] = "\(clientProcessID)"
             process.environment = environment
             process.terminationHandler = { [weak self] _ in
                 self?.lock.withLock {
                     self?.launchedProcess = nil
+                    self?.helperPresence = .notDetermined
                 }
             }
             self.launchedProcess = process
@@ -671,11 +778,6 @@ public final class LKSwiftUISupportGatekeeper: NSObject {
         shared
     }
 
-    @objc(preloadRuntime)
-    public func preloadRuntime() {
-        runtimeBridge.preloadRuntime()
-    }
-
     @objc(shutdownRuntime)
     public func shutdownRuntime() {
         runtimeBridge.shutdownRuntime()
@@ -699,5 +801,13 @@ public final class LKSwiftUISupportGatekeeper: NSObject {
     @objc(allowProtectedFeatureAccessForWindow:)
     public func allowProtectedFeatureAccess(for window: NSWindow?) -> Bool {
         runtimeBridge.allowProtectedFeatureAccess(for: window)
+    }
+
+    @objc public var activationState: LKSwiftUISupportActivationState {
+        runtimeBridge.currentActivationState
+    }
+
+    @objc public func refreshActivationStateInBackground() {
+        runtimeBridge.refreshActivationStateInBackground()
     }
 }

--- a/LookInside/SwiftUISupport/LKSwiftUISupportGatekeeper.swift
+++ b/LookInside/SwiftUISupport/LKSwiftUISupportGatekeeper.swift
@@ -13,6 +13,9 @@ private enum LKSwiftUISupportAuthServerConstants {
     static let relaunchHealthTimeout: TimeInterval = 3.0
     static let helperHealthPollInterval: useconds_t = 100_000
     static let helperShutdownTimeout: TimeInterval = 3
+
+    static let activationStatePollingInterval: DispatchTimeInterval = .seconds(5)
+    static let activationStatePollingLeeway: DispatchTimeInterval = .milliseconds(500)
 }
 
 private enum LKSwiftUISupportHelperPresence {
@@ -24,6 +27,14 @@ private enum LKSwiftUISupportHelperPresence {
     case unknown
     case notActivated
     case activated
+
+    var lkDebugDescription: String {
+        switch self {
+        case .unknown: return "unknown"
+        case .notActivated: return "notActivated"
+        case .activated: return "activated"
+        }
+    }
 }
 
 private struct LKSwiftUISupportAuthServerInstallation {
@@ -150,20 +161,66 @@ private final class LKSwiftUISupportAuthServerBridge {
     private var helperPresence: LKSwiftUISupportHelperPresence = .notDetermined
     private var activationState: LKSwiftUISupportActivationState = .unknown
     private var activationStateRefreshInFlight = false
+    private var activationStatePollingStarted = false
+    private var activationStatePollingTimer: DispatchSourceTimer?
 
     var currentActivationState: LKSwiftUISupportActivationState {
         lock.withLock { activationState }
     }
 
     private func recordDecision(_ decision: LKSwiftUISupportAuthServerAccessDecisionPayload.Decision) {
-        let state: LKSwiftUISupportActivationState
+        let newState: LKSwiftUISupportActivationState
         switch decision {
         case .allow, .allowWithWarning:
-            state = .activated
+            newState = .activated
         case .block:
-            state = .notActivated
+            newState = .notActivated
         }
-        lock.withLock { activationState = state }
+        var previousState: LKSwiftUISupportActivationState = .unknown
+        let changed: Bool = lock.withLock {
+            guard activationState != newState else { return false }
+            previousState = activationState
+            activationState = newState
+            return true
+        }
+        if changed {
+            LKSwiftUISupportLogger.authServer.info(
+                "activation state changed: \(previousState.lkDebugDescription, privacy: .public) -> \(newState.lkDebugDescription, privacy: .public) (decision=\(decision.rawValue, privacy: .public))"
+            )
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: LKSwiftUISupportGatekeeper.activationStateDidChangeNotification,
+                    object: LKSwiftUISupportGatekeeper.sharedInstance(),
+                    userInfo: ["activationState": NSNumber(value: newState.rawValue)]
+                )
+            }
+        }
+    }
+
+    func startActivationStatePolling() {
+        let shouldStart: Bool = lock.withLock {
+            guard !activationStatePollingStarted else { return false }
+            activationStatePollingStarted = true
+            return true
+        }
+        guard shouldStart else { return }
+
+        let interval = LKSwiftUISupportAuthServerConstants.activationStatePollingInterval
+        LKSwiftUISupportLogger.authServer.info(
+            "activation state polling started (interval=\(String(describing: interval), privacy: .public))"
+        )
+
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
+        timer.schedule(
+            deadline: .now(),
+            repeating: interval,
+            leeway: LKSwiftUISupportAuthServerConstants.activationStatePollingLeeway
+        )
+        timer.setEventHandler { [weak self] in
+            self?.refreshActivationStateInBackground()
+        }
+        lock.withLock { activationStatePollingTimer = timer }
+        timer.resume()
     }
 
     func refreshActivationStateInBackground() {
@@ -773,6 +830,19 @@ private extension NSLock {
 public final class LKSwiftUISupportGatekeeper: NSObject {
     private static let shared = LKSwiftUISupportGatekeeper()
     private let runtimeBridge = LKSwiftUISupportAuthServerBridge()
+
+    public static let activationStateDidChangeNotification = Notification.Name(
+        "LKSwiftUISupportActivationStateDidChangeNotification"
+    )
+
+    @objc public static var activationStateDidChangeNotificationName: NSString {
+        activationStateDidChangeNotification.rawValue as NSString
+    }
+
+    override private init() {
+        super.init()
+        runtimeBridge.startActivationStatePolling()
+    }
 
     @objc public class func sharedInstance() -> LKSwiftUISupportGatekeeper {
         shared

--- a/LookInside/SwiftUISupport/LKSwiftUISupportInstaller.swift
+++ b/LookInside/SwiftUISupport/LKSwiftUISupportInstaller.swift
@@ -37,6 +37,7 @@ enum LKSwiftUISupportInstallerError: LocalizedError {
 
 enum LKSwiftUISupportInstallerStage: String {
     case preparing = "Preparing…"
+    case checkingForUpdates = "Checking for updates…"
     case downloading = "Downloading…"
     case extracting = "Extracting…"
     case verifying = "Verifying code signature…"
@@ -47,6 +48,8 @@ enum LKSwiftUISupportInstallerStage: String {
         switch self {
         case .preparing:
             return NSLocalizedString("Preparing…", comment: "")
+        case .checkingForUpdates:
+            return NSLocalizedString("Checking for updates…", comment: "")
         case .downloading:
             return NSLocalizedString("Downloading…", comment: "")
         case .extracting:
@@ -106,6 +109,8 @@ final class LKSwiftUISupportInstaller {
     private let installLock = NSLock()
     private let cacheLock = NSLock()
     private var cachedPublishedVersion: String?
+    private var lastFailedFetchAt: Date?
+    private static let failedFetchCooldown: TimeInterval = 30
 
     func ensureInstalled(presentingWindow: NSWindow?) throws {
         if LKSwiftUISupportInstallerLayout.isInstalled {
@@ -143,9 +148,50 @@ final class LKSwiftUISupportInstaller {
     }
 
     func fetchPublishedVersion() -> String? {
-        if let cached = cacheLock.lkLock({ cachedPublishedVersion }) {
+        let cachedState: (version: String?, cooldownActive: Bool) = cacheLock.lkLock {
+            let cooldown: Bool
+            if let lastFailedFetchAt {
+                cooldown = Date().timeIntervalSince(lastFailedFetchAt) < Self.failedFetchCooldown
+            } else {
+                cooldown = false
+            }
+            return (cachedPublishedVersion, cooldown)
+        }
+        if let cached = cachedState.version {
             return cached
         }
+        if cachedState.cooldownActive {
+            return nil
+        }
+        if Thread.isMainThread {
+            return fetchPublishedVersionPresentingProgress()
+        }
+        return fetchPublishedVersionFromNetwork()
+    }
+
+    private func fetchPublishedVersionPresentingProgress() -> String? {
+        let controller = LKSwiftUISupportInstallerWindowController(
+            title: NSLocalizedString("Checking LookInside Auth Server", comment: "")
+        )
+        controller.updateStage(.checkingForUpdates)
+        controller.showWindow(self)
+
+        var capturedVersion: String?
+        let semaphore = DispatchSemaphore(value: 0)
+        Thread.detachNewThread {
+            capturedVersion = self.fetchPublishedVersionFromNetwork()
+            DispatchQueue.main.async {
+                NSApp.stopModal()
+                semaphore.signal()
+            }
+        }
+        NSApp.runModal(for: controller.window!)
+        _ = semaphore.wait(timeout: .now() + 1)
+        controller.close()
+        return capturedVersion
+    }
+
+    private func fetchPublishedVersionFromNetwork() -> String? {
         var capturedVersion: String?
         let semaphore = DispatchSemaphore(value: 0)
         var request = URLRequest(url: LKSwiftUISupportInstallerLayout.versionURL)
@@ -174,14 +220,22 @@ final class LKSwiftUISupportInstaller {
         }
         task.resume()
         _ = semaphore.wait(timeout: .now() + 6)
-        if let capturedVersion {
-            cacheLock.lkLock { cachedPublishedVersion = capturedVersion }
+        cacheLock.lkLock {
+            if let capturedVersion {
+                cachedPublishedVersion = capturedVersion
+                lastFailedFetchAt = nil
+            } else {
+                lastFailedFetchAt = Date()
+            }
         }
         return capturedVersion
     }
 
     func invalidatePublishedVersionCache() {
-        cacheLock.lkLock { cachedPublishedVersion = nil }
+        cacheLock.lkLock {
+            cachedPublishedVersion = nil
+            lastFailedFetchAt = nil
+        }
     }
 
     func invalidate() {
@@ -485,7 +539,11 @@ final class LKSwiftUISupportInstallerWindowController: NSWindowController {
     private let statusLabel = NSTextField(labelWithString: LKSwiftUISupportInstallerStage.preparing.localizedDescription)
     private let progressIndicator = NSProgressIndicator()
 
-    init() {
+    convenience init() {
+        self.init(title: NSLocalizedString("Installing LookInside Auth Server", comment: ""))
+    }
+
+    init(title: String) {
         let contentRect = NSRect(x: 0, y: 0, width: 360, height: 140)
         let window = NSWindow(
             contentRect: contentRect,
@@ -500,7 +558,7 @@ final class LKSwiftUISupportInstallerWindowController: NSWindowController {
 
         super.init(window: window)
 
-        let titleLabel = NSTextField(labelWithString: NSLocalizedString("Installing LookInside Auth Server", comment: ""))
+        let titleLabel = NSTextField(labelWithString: title)
         titleLabel.font = NSFont.boldSystemFont(ofSize: 13)
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
Wires SwiftUISupportGatekeeper to the auth helper's access decision (allow / allowWithWarning / block) and tracks activation state (unknown / notActivated / activated). The SwiftUI Support menu now restructures itself by activation state, so unactivated users see the trial/activate path and activated users see the normal entries.

Helper lifecycle is tightened around this: preload moves off the main thread and off app startup, spawning only on manual user action. Health check uses a 1s first-launch timeout and 3s relaunch timeout with 100ms polling. The installer modal is reserved for explicit installs; version checks show their own progress modal. The helper is passed the LookInside pid via LOOKINSIDE_AUTH_SERVER_CLIENT_PID so it can bind the session to the caller.