### PR TITLE
Orchestrate LookInsideServer license handshake via Authenticator

### DIFF
--- a/LookInside/Connection/LKAppsManager.m
+++ b/LookInside/Connection/LKAppsManager.m
@@ -128,8 +128,10 @@ NSString *const LKInspectingAppDidEndNotificationName = @"LKInspectingAppDidEndN
         
         NSArray<RACSignal *> *signals = [connectedChannels lookin_map:^id(NSUInteger idx, Lookin_PTChannel *channel) {
             return [[[LKConnectionManager sharedInstance] requestWithType:LookinRequestTypeApp data:params channel:channel] catch:^RACSignal * _Nonnull(NSError * _Nonnull error) {
-                if (error.code == LookinErrCode_ServerVersionTooHigh || error.code == LookinErrCode_ServerVersionTooLow) {
-                    // 这些 Lookin 版本不匹配的错误应该被保留，因为业务需要显示这些错误
+                if (error.code == LookinErrCode_ServerVersionTooHigh ||
+                    error.code == LookinErrCode_ServerVersionTooLow ||
+                    error.code == LookinErrCode_LicenseRequired) {
+                    // 这些 Lookin 版本不匹配 / 许可校验失败的错误应该被保留，因为业务需要显示这些错误
                     return [RACSignal return:error];
                 } else {
                     // 位于后台无法执行代码的 channel 会走到这里，应该过滤掉这些 channel

--- a/LookInside/Connection/LKConnectionManager.m
+++ b/LookInside/Connection/LKConnectionManager.m
@@ -14,6 +14,7 @@
 #import "LookinAppInfo.h"
 #import "LKConnectionRequest.h"
 #import "LKServerVersionRequestor.h"
+#import "LookInside-Swift.h"
 
 static NSIndexSet * PushFrameTypeList(void) {
     static NSIndexSet *list;
@@ -30,6 +31,11 @@ static NSIndexSet * PushFrameTypeList(void) {
 /// 已经发送但尚未收到全部回复的请求
 @property(nonatomic, strong) NSMutableSet<LKConnectionRequest *> *activeRequests;
 
+/// YES once the license handshake has succeeded on this channel. Reset on
+/// channel end. Consulted by `requestWithType:data:channel:` before dispatching
+/// a non-exempt request.
+@property(nonatomic, assign) BOOL isLicenseVerified;
+
 @end
 
 @implementation Lookin_PTChannel (LKConnection)
@@ -40,6 +46,14 @@ static NSIndexSet * PushFrameTypeList(void) {
 
 - (NSMutableSet<LKConnectionRequest *> *)activeRequests {
     return [self lookin_getBindObjectForKey:@"activeRequest"];
+}
+
+- (void)setIsLicenseVerified:(BOOL)isLicenseVerified {
+    [self lookin_bindObject:@(isLicenseVerified) forKey:@"isLicenseVerified"];
+}
+
+- (BOOL)isLicenseVerified {
+    return [[self lookin_getBindObjectForKey:@"isLicenseVerified"] boolValue];
 }
 
 @end
@@ -326,8 +340,10 @@ static NSIndexSet * PushFrameTypeList(void) {
             if (versionErr) {
                 // LookinServer 版本有问题
                 [subscriber sendError:versionErr];
-            } else {
-                // 没问题，开始发真正请求
+                return;
+            }
+
+            void (^dispatchRealRequest)(void) = ^{
                 [self _requestWithType:requestType channel:channel data:requestData timeoutInterval:5 succ:^(id responseData) {
                     RACTuple *tupleResult = [RACTuple tupleWithObjects:responseData, channel, nil];
                     [subscriber sendNext:tupleResult];
@@ -336,15 +352,85 @@ static NSIndexSet * PushFrameTypeList(void) {
                 } completion:^{
                     [subscriber sendCompleted];
                 }];
+            };
+
+            if (channel.isLicenseVerified) {
+                dispatchRealRequest();
+                return;
             }
-            
+
+            [self _performLicenseHandshakeOnChannel:channel succ:^{
+                dispatchRealRequest();
+            } fail:^(NSError *error) {
+                [subscriber sendError:error];
+            }];
+
         } fail:^(NSError *error) {
             // ping 失败了
             [subscriber sendError:error];
-            
+
         } completion:nil];
         return nil;
     }];
+}
+
+- (void)_performLicenseHandshakeOnChannel:(Lookin_PTChannel *)channel
+                                     succ:(void (^)(void))succBlock
+                                     fail:(void (^)(NSError *error))failBlock {
+    [self _requestWithType:LookinRequestTypeLicenseChallenge channel:channel data:nil timeoutInterval:5 succ:^(LookinConnectionResponseAttachment *challengeAttachment) {
+        NSDictionary *challenge = [challengeAttachment.data isKindOfClass:[NSDictionary class]] ? (NSDictionary *)challengeAttachment.data : nil;
+        NSData *nonce = [challenge[@"nonce"] isKindOfClass:[NSData class]] ? challenge[@"nonce"] : nil;
+        NSString *serverID = [challenge[@"server_instance_id"] isKindOfClass:[NSString class]] ? challenge[@"server_instance_id"] : nil;
+        if (nonce.length != 32 || serverID.length == 0) {
+            if (failBlock) {
+                failBlock([NSError errorWithDomain:LookinErrorDomain code:LookinErrCode_Inner userInfo:@{NSLocalizedDescriptionKey:NSLocalizedString(@"License challenge payload is malformed.", nil)}]);
+            }
+            return;
+        }
+
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            NSError *signError = nil;
+            NSData *signature = nil;
+            NSData *intermediateCertDER = nil;
+            NSString *udid = nil;
+            BOOL ok = [[LKSwiftUISupportGatekeeper sharedInstance]
+                signChallengeWithNonce:nonce
+                      serverInstanceID:serverID
+                             signature:&signature
+                   intermediateCertDER:&intermediateCertDER
+                                  udid:&udid
+                                 error:&signError];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (!ok || signature.length == 0 || intermediateCertDER.length == 0) {
+                    NSString *detail = signError.localizedDescription ?: NSLocalizedString(@"License signing failed.", nil);
+                    NSError *reportedError = [NSError errorWithDomain:LookinErrorDomain
+                                                                 code:LookinErrCode_LicenseRequired
+                                                             userInfo:@{
+                                                                 NSLocalizedDescriptionKey: NSLocalizedString(@"LookInside license verification failed.", nil),
+                                                                 NSLocalizedRecoverySuggestionErrorKey: detail,
+                                                             }];
+                    if (failBlock) failBlock(reportedError);
+                    return;
+                }
+
+                NSDictionary *verifyPayload = @{
+                    @"nonce":                 nonce,
+                    @"server_instance_id":    serverID,
+                    @"signature":             signature,
+                    @"intermediate_cert_der": intermediateCertDER,
+                    @"udid":                  udid ?: @"",
+                };
+                [self _requestWithType:LookinRequestTypeLicenseVerify channel:channel data:verifyPayload timeoutInterval:5 succ:^(id verifyResponse) {
+                    channel.isLicenseVerified = YES;
+                    if (succBlock) succBlock();
+                } fail:^(NSError *verifyError) {
+                    if (failBlock) failBlock(verifyError);
+                } completion:nil];
+            });
+        });
+    } fail:^(NSError *challengeError) {
+        if (failBlock) failBlock(challengeError);
+    } completion:nil];
 }
 
 - (NSError *)_checkServerVersionWithResponse:(LookinConnectionResponseAttachment *)pingResponse {

--- a/LookInside/Launch/LKLaunchAppView.m
+++ b/LookInside/Launch/LKLaunchAppView.m
@@ -138,10 +138,13 @@
         
         if (app.serverVersionError.code == LookinErrCode_ServerVersionTooLow) {
             self.errorTitleLabel.stringValue = NSLocalizedString(@"The version of LookinServer linked with this iOS App is too low.", nil);
-            
+
         } else if (app.serverVersionError.code == LookinErrCode_ServerVersionTooHigh) {
             self.errorTitleLabel.stringValue = NSLocalizedString(@"Unable to inspect this iOS App. Current version of LookInside app is too low.", nil);
-            
+
+        } else if (app.serverVersionError.code == LookinErrCode_LicenseRequired) {
+            self.errorTitleLabel.stringValue = NSLocalizedString(@"LookInside license verification is required to inspect this app.", nil);
+
         } else {
             self.errorTitleLabel.stringValue = @"Unknown Error";
             NSAssert(NO, @"");

--- a/LookInside/Launch/LKLaunchViewController.m
+++ b/LookInside/Launch/LKLaunchViewController.m
@@ -16,6 +16,7 @@
 #import "LKPreferenceManager.h"
 #import "LKTextControl.h"
 #import "LKPerformanceReporter.h"
+#import "LookInside-Swift.h"
 
 @interface LKLaunchViewController () <NSGestureRecognizerDelegate>
 
@@ -127,10 +128,12 @@
     if (view.app.serverVersionError) {
         if (view.app.serverVersionError.code == LookinErrCode_ServerVersionTooLow) {
             [LKHelper openLookinWebsiteWithPath:@"faq/server-version-too-low/"];
+        } else if (view.app.serverVersionError.code == LookinErrCode_LicenseRequired) {
+            [[LKSwiftUISupportGatekeeper sharedInstance] showLicenseWindow];
         } else {
             [LKHelper openLookinWebsiteWithPath:@"faq/server-version-too-high/"];
         }
-        
+
     } else {
         [self.bottomIndicatorView animateToProgress:.8 duration:1];
         

--- a/LookInside/SwiftUISupport/LKSwiftUISupportGatekeeper.swift
+++ b/LookInside/SwiftUISupport/LKSwiftUISupportGatekeeper.swift
@@ -52,6 +52,28 @@ private struct LKSwiftUISupportClientProcessPayload: Encodable {
     }
 }
 
+private struct LKSwiftUISupportSignChallengeRequestPayload: Encodable {
+    let nonce: String
+    let serverInstanceID: String
+
+    private enum CodingKeys: String, CodingKey {
+        case nonce
+        case serverInstanceID = "server_instance_id"
+    }
+}
+
+private struct LKSwiftUISupportSignChallengeResponsePayload: Decodable {
+    let signature: String
+    let intermediateCertDER: String
+    let udid: String
+
+    private enum CodingKeys: String, CodingKey {
+        case signature
+        case intermediateCertDER = "intermediate_cert_der"
+        case udid
+    }
+}
+
 private struct LKSwiftUISupportAuthServerRequestEnvelope<Payload: Encodable>: Encodable {
     let protocolVersion: Int
     let requestID: String
@@ -372,6 +394,31 @@ private final class LKSwiftUISupportAuthServerBridge {
         } catch {
             presentRuntimeAlert(title: NSLocalizedString("LookInside Auth Server Required", comment: ""), detail: error.localizedDescription, window: window)
         }
+    }
+
+    func signChallenge(
+        nonce: Data,
+        serverInstanceID: String
+    ) throws -> (signature: Data, intermediateCertDER: Data, udid: String) {
+        let installation = try ensureInstalledAndRunning(window: nil)
+        let nonceHex = nonce.map { String(format: "%02x", $0) }.joined()
+        let response = try sendRequest(
+            method: "license.sign_challenge",
+            payload: LKSwiftUISupportSignChallengeRequestPayload(
+                nonce: nonceHex,
+                serverInstanceID: serverInstanceID
+            ),
+            installation: installation,
+            responseType: LKSwiftUISupportSignChallengeResponsePayload.self
+        )
+        guard let payload = response.payload else {
+            throw LKSwiftUISupportAuthServerError.invalidResponse("Missing sign-challenge payload.")
+        }
+        guard let signature = Data(base64Encoded: payload.signature),
+              let intermediateDER = Data(base64Encoded: payload.intermediateCertDER) else {
+            throw LKSwiftUISupportAuthServerError.invalidResponse("Sign-challenge payload base64 decode failed.")
+        }
+        return (signature, intermediateDER, payload.udid)
     }
 
     func allowProtectedFeatureAccess(for window: NSWindow?) -> Bool {
@@ -879,5 +926,28 @@ public final class LKSwiftUISupportGatekeeper: NSObject {
 
     @objc public func refreshActivationStateInBackground() {
         runtimeBridge.refreshActivationStateInBackground()
+    }
+
+    /// Requests a signature over `nonce || server_instance_id.utf8` from the
+    /// local Auth helper. On success writes the RSA-PKCS1v15-SHA256 signature
+    /// to `signatureOut`, the DER-encoded intermediate certificate to
+    /// `intermediateCertDEROut`, and the device UDID to `udidOut`. Returns
+    /// `NO` and populates `error` on any failure (no helper, socket error,
+    /// license not activated, signing failed, etc.).
+    @objc(signChallengeWithNonce:serverInstanceID:signature:intermediateCertDER:udid:error:)
+    public func signChallenge(
+        nonce: Data,
+        serverInstanceID: String,
+        signature signatureOut: AutoreleasingUnsafeMutablePointer<NSData?>,
+        intermediateCertDER intermediateCertDEROut: AutoreleasingUnsafeMutablePointer<NSData?>,
+        udid udidOut: AutoreleasingUnsafeMutablePointer<NSString?>
+    ) throws {
+        let result = try runtimeBridge.signChallenge(
+            nonce: nonce,
+            serverInstanceID: serverInstanceID
+        )
+        signatureOut.pointee = result.signature as NSData
+        intermediateCertDEROut.pointee = result.intermediateCertDER as NSData
+        udidOut.pointee = result.udid as NSString
     }
 }

--- a/Sources/LookinCore/LookinDefines.h
+++ b/Sources/LookinCore/LookinDefines.h
@@ -20,18 +20,18 @@
 #pragma mark - Version
 
 /// current connection protocol version of LookinServer
-static const int LOOKIN_SERVER_VERSION = 7;
+static const int LOOKIN_SERVER_VERSION = 8;
 
 /// current release version of LookinServer
-static NSString * const LOOKIN_SERVER_READABLE_VERSION = @"1.2.8";
+static NSString * const LOOKIN_SERVER_READABLE_VERSION = @"1.3.0";
 
 /// current connection protocol version of LookinClient
-static const int LOOKIN_CLIENT_VERSION = 7;
+static const int LOOKIN_CLIENT_VERSION = 8;
 
 /// the minimum connection protocol version supported by current LookinClient
-static const int LOOKIN_SUPPORTED_SERVER_MIN = 7;
+static const int LOOKIN_SUPPORTED_SERVER_MIN = 8;
 /// the maximum connection protocol version supported by current LookinClient
-static const int LOOKIN_SUPPORTED_SERVER_MAX = 7;
+static const int LOOKIN_SUPPORTED_SERVER_MAX = 8;
 
 #pragma mark - Connection
 
@@ -80,7 +80,12 @@ enum {
     
     /// 请求修改某个自定义 Attribute 的值
     LookinRequestTypeCustomAttrModification = 214,
-    
+
+    /// License 握手：Server → Host 发起 challenge（返回 nonce + server_instance_id）
+    LookinRequestTypeLicenseChallenge = 220,
+    /// License 握手：Host → Server 提交签名 + 中间证书供校验
+    LookinRequestTypeLicenseVerify = 221,
+
     /// 从 LookinServer 1.2.7 & Lookin 1.0.7 开始，该属性被废弃、不再使用
     LookinPush_BringForwardScreenshotTask = 303,
     
@@ -123,6 +128,9 @@ enum {
     LookinErrCode_ModifyValueTypeInvalid = -501,
     LookinErrCode_Exception = -502,
     
+    /// License 校验失败，Host 未激活 LookInside 许可证
+    LookinErrCode_LicenseRequired = -408,
+
     // LookinServer 版本过高，要升级 client
     LookinErrCode_ServerVersionTooHigh = -600,
     // LookinServer 版本过低，要升级 server

--- a/Sources/LookinServer/Shared/LookinDefines.h
+++ b/Sources/LookinServer/Shared/LookinDefines.h
@@ -20,18 +20,18 @@
 #pragma mark - Version
 
 /// current connection protocol version of LookinServer
-static const int LOOKIN_SERVER_VERSION = 7;
+static const int LOOKIN_SERVER_VERSION = 8;
 
 /// current release version of LookinServer
-static NSString * const LOOKIN_SERVER_READABLE_VERSION = @"1.2.8";
+static NSString * const LOOKIN_SERVER_READABLE_VERSION = @"1.3.0";
 
 /// current connection protocol version of LookinClient
-static const int LOOKIN_CLIENT_VERSION = 7;
+static const int LOOKIN_CLIENT_VERSION = 8;
 
 /// the minimum connection protocol version supported by current LookinClient
-static const int LOOKIN_SUPPORTED_SERVER_MIN = 7;
+static const int LOOKIN_SUPPORTED_SERVER_MIN = 8;
 /// the maximum connection protocol version supported by current LookinClient
-static const int LOOKIN_SUPPORTED_SERVER_MAX = 7;
+static const int LOOKIN_SUPPORTED_SERVER_MAX = 8;
 
 #pragma mark - Connection
 
@@ -80,7 +80,12 @@ enum {
     
     /// 请求修改某个自定义 Attribute 的值
     LookinRequestTypeCustomAttrModification = 214,
-    
+
+    /// License 握手：Server → Host 发起 challenge（返回 nonce + server_instance_id）
+    LookinRequestTypeLicenseChallenge = 220,
+    /// License 握手：Host → Server 提交签名 + 中间证书供校验
+    LookinRequestTypeLicenseVerify = 221,
+
     /// 从 LookinServer 1.2.7 & Lookin 1.0.7 开始，该属性被废弃、不再使用
     LookinPush_BringForwardScreenshotTask = 303,
     
@@ -123,6 +128,9 @@ enum {
     LookinErrCode_ModifyValueTypeInvalid = -501,
     LookinErrCode_Exception = -502,
     
+    /// License 校验失败，Host 未激活 LookInside 许可证
+    LookinErrCode_LicenseRequired = -408,
+
     // LookinServer 版本过高，要升级 client
     LookinErrCode_ServerVersionTooHigh = -600,
     // LookinServer 版本过低，要升级 server


### PR DESCRIPTION
## Summary

- After Ping + version negotiation, the Host App now drives the new `LookinRequestTypeLicenseChallenge` / `LookinRequestTypeLicenseVerify` pair against LookInsideServer before issuing any inspection RPC.
- The signed payload is produced by `LKSwiftUISupportGatekeeper.signChallenge`, which talks to the Authenticator over its existing Unix socket.
- `LookinErrCode_LicenseRequired` (-408) from the server now surfaces as an activation prompt that routes into the existing license window. Versions bumped to 8 / 1.3.0.

## Companion commits

- LookInsideServer: license-handshake protocol (types 220/221) with SecTrust chain verify — `main @ 1fd9f53`.
- LookInsideAuthenticator: `license.sign_challenge` method — `main @ 0e362db`.
- LookInsideWeb: self-signed root CA DER published at `/roots/lookinside-root-2026.der` — live.

## Test plan

- [x] `lookinside-licensing-smoke` — 9/9 pass against synthetic openssl chains (happy path + 5 failure modes).
- [x] Host App builds clean (`xcodebuild -scheme LookInside -configuration Debug`).
- [ ] CI: macOS/iOS matrix build on this branch.
- [ ] Manual end-to-end: Authenticator (signed via shim `sign-auth-server` workflow) ↔ Host App ↔ demo target with updated LookInsideServer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)