### PR TITLE
Make request timeouts configurable

### DIFF
--- a/LookInside/Connection/LKConnectionManager.m
+++ b/LookInside/Connection/LKConnectionManager.m
@@ -44,7 +44,7 @@ static NSTimeInterval LKRequestTimeoutIntervalForRequestType(unsigned int reques
     switch (requestType) {
         case LookinRequestTypeHierarchy:
         case LookinRequestTypeHierarchyDetails:
-            return 15;
+            return LKPreferenceManager.mainManager.hierarchyRequestTimeoutInterval;
         default:
             return 5;
     }
@@ -485,7 +485,8 @@ static NSTimeInterval LKRequestTimeoutIntervalForRequestType(unsigned int reques
                                      succ:(void (^)(void))succBlock
                                      fail:(void (^)(NSError *error))failBlock {
     NSLog(@"LookInside - License: starting handshake on channel %p (sending 220 LicenseChallenge).", channel);
-    [self _requestWithType:LookinRequestTypeLicenseChallenge channel:channel data:nil timeoutInterval:5 succ:^(LookinConnectionResponseAttachment *challengeAttachment) {
+    NSTimeInterval timeoutInterval = LKPreferenceManager.mainManager.licenseHandshakeTimeoutInterval;
+    [self _requestWithType:LookinRequestTypeLicenseChallenge channel:channel data:nil timeoutInterval:timeoutInterval succ:^(LookinConnectionResponseAttachment *challengeAttachment) {
         if (challengeAttachment.error) {
             NSLog(@"LookInside - License: 220 challenge errored: %@", challengeAttachment.error.localizedDescription);
             if (failBlock) failBlock(challengeAttachment.error);
@@ -538,7 +539,7 @@ static NSTimeInterval LKRequestTimeoutIntervalForRequestType(unsigned int reques
                     @"intermediate_cert_der": intermediateCertDER,
                     @"udid":                  udid ?: @"",
                 };
-                [self _requestWithType:LookinRequestTypeLicenseVerify channel:channel data:verifyPayload timeoutInterval:5 succ:^(LookinConnectionResponseAttachment *verifyResponse) {
+                [self _requestWithType:LookinRequestTypeLicenseVerify channel:channel data:verifyPayload timeoutInterval:timeoutInterval succ:^(LookinConnectionResponseAttachment *verifyResponse) {
                     if (verifyResponse.error) {
                         NSLog(@"LookInside - License: 221 verify rejected by server: %@", verifyResponse.error.localizedDescription);
                         if (failBlock) failBlock(verifyResponse.error);

--- a/LookInside/Localizable.xcstrings
+++ b/LookInside/Localizable.xcstrings
@@ -1563,6 +1563,22 @@
         }
       }
     },
+    "License Timeout" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "License Timeout"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "License 超时"
+          }
+        }
+      }
+    },
     "Light Mode" : {
       "localizations" : {
         "en" : {
@@ -2371,6 +2387,22 @@
         }
       }
     },
+    "Hierarchy Timeout" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hierarchy Timeout"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "层级请求超时"
+          }
+        }
+      }
+    },
     "Request timeout" : {
       "localizations" : {
         "en" : {
@@ -3113,6 +3145,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在验证代码签名…"
+          }
+        }
+      }
+    },
+    "Timeout for license challenge and verification requests, in seconds. Default: 5s." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout for license challenge and verification requests, in seconds. Default: 5s."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "License challenge 和 verify 请求的超时时间，单位秒。默认 5 秒。"
+          }
+        }
+      }
+    },
+    "Timeout for hierarchy and hierarchy-details requests, in seconds. Default: 15s." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout for hierarchy and hierarchy-details requests, in seconds. Default: 15s."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hierarchy 和 HierarchyDetails 请求的超时时间，单位秒。默认 15 秒。"
           }
         }
       }

--- a/LookInside/Manager/LKPreferenceManager.h
+++ b/LookInside/Manager/LKPreferenceManager.h
@@ -17,6 +17,10 @@ extern NSString *const LKWindowSizeName_Static;
 /// 初始的 preview scale
 extern const CGFloat LKInitialPreviewScale;
 
+/// 默认的层级请求超时时间，单位秒。
+extern const NSTimeInterval LKDefaultHierarchyRequestTimeoutInterval;
+extern const NSTimeInterval LKDefaultLicenseHandshakeTimeoutInterval;
+
 typedef NS_ENUM(NSInteger, LookinPreferredAppeanranceType) {
     LookinPreferredAppeanranceTypeDark,
     LookinPreferredAppeanranceTypeLight,
@@ -75,6 +79,10 @@ typedef NS_ENUM(NSInteger, LookinMeasureState) {
 @property(nonatomic, copy) NSArray<LookinAttrGroupIdentifier> *collapsedAttrGroups;
 
 @property(nonatomic, assign) CGFloat preferredExportCompression;
+
+@property(nonatomic, assign) NSTimeInterval hierarchyRequestTimeoutInterval;
+
+@property(nonatomic, assign) NSTimeInterval licenseHandshakeTimeoutInterval;
 
 @property(nonatomic, strong, readonly) LookinBOOLMsgAttribute *freeRotation;
 

--- a/LookInside/Manager/LKPreferenceManager.m
+++ b/LookInside/Manager/LKPreferenceManager.m
@@ -16,6 +16,8 @@ NSString *const LKWindowSizeName_Dynamic = @"LKWindowSizeName_Dynamic";
 NSString *const LKWindowSizeName_Static = @"LKWindowSizeName_Static";
 
 const CGFloat LKInitialPreviewScale = 0.27;
+const NSTimeInterval LKDefaultHierarchyRequestTimeoutInterval = 15;
+const NSTimeInterval LKDefaultLicenseHandshakeTimeoutInterval = 5;
 
 static NSString * const Key_PreviousClientVersion = @"preVer";
 static NSString * const Key_ShowOutline = @"showOutline";
@@ -29,6 +31,8 @@ static NSString * const Key_ContrastLevel = @"contrastLevel";
 static NSString * const Key_SectionsShow = @"ss";
 static NSString * const Key_CollapsedGroups = @"collapsedGroups_918";
 static NSString * const Key_PreferredExportCompression = @"preferredExportCompression";
+static NSString * const Key_HierarchyRequestTimeoutInterval = @"hierarchyRequestTimeoutInterval";
+static NSString * const Key_LicenseHandshakeTimeoutInterval = @"licenseHandshakeTimeoutInterval";
 static NSString * const Key_CallStackType = @"callStackType";
 static NSString * const Key_SyncConsoleTarget = @"syncConsoleTarget";
 static NSString * const Key_FreeRotation = @"FreeRotation";
@@ -186,6 +190,22 @@ static NSString * const Key_ReceivingConfigTime_Class = @"ConfigTime_Class";
             _preferredExportCompression = .5;
             [userDefaults setObject:@(_preferredExportCompression) forKey:Key_PreferredExportCompression];
         }
+
+        NSNumber *obj_hierarchyRequestTimeoutInterval = [userDefaults objectForKey:Key_HierarchyRequestTimeoutInterval];
+        if (obj_hierarchyRequestTimeoutInterval != nil && [obj_hierarchyRequestTimeoutInterval doubleValue] > 0) {
+            _hierarchyRequestTimeoutInterval = [obj_hierarchyRequestTimeoutInterval doubleValue];
+        } else {
+            _hierarchyRequestTimeoutInterval = LKDefaultHierarchyRequestTimeoutInterval;
+            [userDefaults setObject:@(_hierarchyRequestTimeoutInterval) forKey:Key_HierarchyRequestTimeoutInterval];
+        }
+
+        NSNumber *obj_licenseHandshakeTimeoutInterval = [userDefaults objectForKey:Key_LicenseHandshakeTimeoutInterval];
+        if (obj_licenseHandshakeTimeoutInterval != nil && [obj_licenseHandshakeTimeoutInterval doubleValue] > 0) {
+            _licenseHandshakeTimeoutInterval = [obj_licenseHandshakeTimeoutInterval doubleValue];
+        } else {
+            _licenseHandshakeTimeoutInterval = LKDefaultLicenseHandshakeTimeoutInterval;
+            [userDefaults setObject:@(_licenseHandshakeTimeoutInterval) forKey:Key_LicenseHandshakeTimeoutInterval];
+        }
         
         _receivingConfigTime_Color = [userDefaults doubleForKey:Key_ReceivingConfigTime_Color];
         _receivingConfigTime_Class = [userDefaults doubleForKey:Key_ReceivingConfigTime_Class];
@@ -267,6 +287,32 @@ static NSString * const Key_ReceivingConfigTime_Class = @"ConfigTime_Class";
     _preferredExportCompression = preferredExportCompression;
     if (self.shouldStoreToLocal) {
         [[NSUserDefaults standardUserDefaults] setObject:@(preferredExportCompression) forKey:Key_PreferredExportCompression];
+    }
+}
+
+- (void)setHierarchyRequestTimeoutInterval:(NSTimeInterval)hierarchyRequestTimeoutInterval {
+    if (hierarchyRequestTimeoutInterval <= 0) {
+        hierarchyRequestTimeoutInterval = LKDefaultHierarchyRequestTimeoutInterval;
+    }
+    if (_hierarchyRequestTimeoutInterval == hierarchyRequestTimeoutInterval) {
+        return;
+    }
+    _hierarchyRequestTimeoutInterval = hierarchyRequestTimeoutInterval;
+    if (self.shouldStoreToLocal) {
+        [[NSUserDefaults standardUserDefaults] setObject:@(hierarchyRequestTimeoutInterval) forKey:Key_HierarchyRequestTimeoutInterval];
+    }
+}
+
+- (void)setLicenseHandshakeTimeoutInterval:(NSTimeInterval)licenseHandshakeTimeoutInterval {
+    if (licenseHandshakeTimeoutInterval <= 0) {
+        licenseHandshakeTimeoutInterval = LKDefaultLicenseHandshakeTimeoutInterval;
+    }
+    if (_licenseHandshakeTimeoutInterval == licenseHandshakeTimeoutInterval) {
+        return;
+    }
+    _licenseHandshakeTimeoutInterval = licenseHandshakeTimeoutInterval;
+    if (self.shouldStoreToLocal) {
+        [[NSUserDefaults standardUserDefaults] setObject:@(licenseHandshakeTimeoutInterval) forKey:Key_LicenseHandshakeTimeoutInterval];
     }
 }
 

--- a/LookInside/Preference/LKPreferenceViewController.m
+++ b/LookInside/Preference/LKPreferenceViewController.m
@@ -12,12 +12,109 @@
 #import "LKNavigationManager.h"
 #import "LKMessageManager.h"
 
+@interface LKPreferenceNumberInputView : LKBaseView <NSTextFieldDelegate>
+
+- (instancetype)initWithTitle:(NSString *)title message:(NSString *)message;
+
+@property(nonatomic, assign) CGFloat buttonX;
+@property(nonatomic, assign) double doubleValue;
+@property(nonatomic, copy) void (^didChange)(double doubleValue);
+
+@end
+
+@interface LKPreferenceNumberInputView ()
+
+@property(nonatomic, strong) LKLabel *titleLabel;
+@property(nonatomic, strong) NSTextField *textField;
+@property(nonatomic, strong) LKLabel *messageLabel;
+
+@end
+
+@implementation LKPreferenceNumberInputView
+
+- (instancetype)initWithTitle:(NSString *)title message:(NSString *)message {
+    if (self = [self initWithFrame:NSZeroRect]) {
+        self.titleLabel = [LKLabel new];
+        self.titleLabel.stringValue = title;
+        self.titleLabel.font = NSFontMake(IsEnglish ? 13 : 15);
+        [self addSubview:self.titleLabel];
+
+        self.textField = [NSTextField new];
+        self.textField.font = NSFontMake(IsEnglish ? 13 : 14);
+        self.textField.alignment = NSTextAlignmentRight;
+        self.textField.delegate = self;
+        [self addSubview:self.textField];
+
+        self.messageLabel = [LKLabel new];
+        self.messageLabel.stringValue = message;
+        self.messageLabel.font = NSFontMake(IsEnglish ? 12 : 13);
+        self.messageLabel.textColor = [NSColor secondaryLabelColor];
+        self.messageLabel.maximumNumberOfLines = 0;
+        [self addSubview:self.messageLabel];
+    }
+    return self;
+}
+
+- (void)layout {
+    [super layout];
+    CGFloat textFieldHeight = [self.textField sizeThatFits:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX)].height + 2;
+    $(self.textField).width(90).height(textFieldHeight).x(self.buttonX).y(0);
+    $(self.messageLabel).x(self.textField.$x).toRight(0).y(self.textField.$maxY + 4).toBottom(0);
+    $(self.titleLabel).sizeToFit.maxX(self.buttonX - 3).y(0);
+}
+
+- (void)setButtonX:(CGFloat)buttonX {
+    _buttonX = buttonX;
+    [self setNeedsLayout:YES];
+}
+
+- (void)setDoubleValue:(double)doubleValue {
+    _doubleValue = doubleValue;
+    self.textField.stringValue = [self _displayStringFromDouble:doubleValue];
+}
+
+- (void)controlTextDidEndEditing:(NSNotification *)notification {
+    [self _commitTextField];
+}
+
+- (void)_commitTextField {
+    NSString *inputString = [self.textField.stringValue ?: @"" stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSScanner *scanner = [NSScanner scannerWithString:inputString];
+    double newValue = 0;
+    BOOL didScan = [scanner scanDouble:&newValue];
+    if (didScan && scanner.isAtEnd && newValue > 0) {
+        self.doubleValue = newValue;
+        if (self.didChange) {
+            self.didChange(newValue);
+        }
+    } else {
+        self.textField.stringValue = [self _displayStringFromDouble:self.doubleValue];
+    }
+}
+
+- (NSString *)_displayStringFromDouble:(double)value {
+    NSString *string = [NSString stringWithFormat:@"%.2f", value];
+    while ([string containsString:@"."] && [string hasSuffix:@"0"]) {
+        string = [string substringToIndex:string.length - 1];
+    }
+    if ([string hasSuffix:@"."]) {
+        string = [string substringToIndex:string.length - 1];
+    }
+    return string;
+}
+
+@end
+
 @interface LKPreferenceViewController ()
 
 @property(nonatomic, strong) LKPreferencePopupView *view_doubleClick;
 @property(nonatomic, strong) LKPreferencePopupView *view_appearance;
 @property(nonatomic, strong) LKPreferencePopupView *view_colorFormat;
 @property(nonatomic, strong) LKPreferencePopupView *view_contrast;
+@property(nonatomic, strong) LKPreferenceNumberInputView *view_hierarchyTimeout;
+#if DEBUG
+@property(nonatomic, strong) LKPreferenceNumberInputView *view_licenseTimeout;
+#endif
 
 //@property(nonatomic, strong) NSButton *debugButton;
 @property(nonatomic, strong) NSButton *resetButton;
@@ -62,6 +159,22 @@
         [LKPreferenceManager mainManager].doubleClickBehavior = selectedIndex;
     };
     [self.view addSubview:self.view_doubleClick];
+
+    self.view_hierarchyTimeout = [[LKPreferenceNumberInputView alloc] initWithTitle:NSLocalizedString(@"Hierarchy Timeout", nil) message:NSLocalizedString(@"Timeout for hierarchy and hierarchy-details requests, in seconds. Default: 15s.", nil)];
+    self.view_hierarchyTimeout.buttonX = controlX;
+    self.view_hierarchyTimeout.didChange = ^(double doubleValue) {
+        [LKPreferenceManager mainManager].hierarchyRequestTimeoutInterval = doubleValue;
+    };
+    [self.view addSubview:self.view_hierarchyTimeout];
+
+#if DEBUG
+    self.view_licenseTimeout = [[LKPreferenceNumberInputView alloc] initWithTitle:NSLocalizedString(@"License Timeout", nil) message:NSLocalizedString(@"Timeout for license challenge and verification requests, in seconds. Default: 5s.", nil)];
+    self.view_licenseTimeout.buttonX = controlX;
+    self.view_licenseTimeout.didChange = ^(double doubleValue) {
+        [LKPreferenceManager mainManager].licenseHandshakeTimeoutInterval = doubleValue;
+    };
+    [self.view addSubview:self.view_licenseTimeout];
+#endif
     
 //    self.debugButton = [NSButton lk_normalButtonWithTitle:@"Debug" target:self action:@selector(_handleDebugButton)];
 //    [self.view addSubview:self.debugButton];
@@ -85,6 +198,10 @@
 
     self.view_appearance.selectedIndex = manager.appearanceType;
     self.view_doubleClick.selectedIndex = manager.doubleClickBehavior;
+    self.view_hierarchyTimeout.doubleValue = manager.hierarchyRequestTimeoutInterval;
+#if DEBUG
+    self.view_licenseTimeout.doubleValue = manager.licenseHandshakeTimeoutInterval;
+#endif
 }
 
 - (void)viewDidLayout {
@@ -98,6 +215,10 @@
     $(self.view_contrast).x(insets.left).toRight(insets.right).y(self.view_colorFormat.$maxY).height(65);
     
     $(self.view_doubleClick).x(insets.left).toRight(insets.right).y(self.view_contrast.$maxY).height(50);
+    $(self.view_hierarchyTimeout).x(insets.left).toRight(insets.right).y(self.view_doubleClick.$maxY).height(65);
+#if DEBUG
+    $(self.view_licenseTimeout).x(insets.left).toRight(insets.right).y(self.view_hierarchyTimeout.$maxY).height(65);
+#endif
     
     $(self.resetButton).width(120).bottom(insets.bottom).right(insets.right);
 //    $(self.debugButton).bottom(insets.bottom).maxX(self.resetButton.$x - 15);
@@ -109,6 +230,8 @@
     manager.rgbaFormat = YES;
     manager.doubleClickBehavior = LookinDoubleClickBehaviorCollapse;
     manager.imageContrastLevel = 0;
+    manager.hierarchyRequestTimeoutInterval = LKDefaultHierarchyRequestTimeoutInterval;
+    manager.licenseHandshakeTimeoutInterval = LKDefaultLicenseHandshakeTimeoutInterval;
     [self renderFromPreferenceManager];
     
 #if DEBUG

--- a/LookInside/Preference/LKPreferenceWindowController.m
+++ b/LookInside/Preference/LKPreferenceWindowController.m
@@ -13,7 +13,11 @@
 @implementation LKPreferenceWindowController
 
 - (instancetype)init {
-    LKWindow *window = [[LKWindow alloc] initWithContentRect:NSMakeRect(0, 0, 600, 380) styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|NSWindowStyleMaskMiniaturizable backing:NSBackingStoreBuffered defer:YES];
+    CGFloat windowHeight = 410;
+#if DEBUG
+    windowHeight = 475;
+#endif
+    LKWindow *window = [[LKWindow alloc] initWithContentRect:NSMakeRect(0, 0, 600, windowHeight) styleMask:NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|NSWindowStyleMaskMiniaturizable backing:NSBackingStoreBuffered defer:YES];
     window.movableByWindowBackground = YES;
     window.title = NSLocalizedString(@"Preferences", nil);
     [window center];


### PR DESCRIPTION
## Summary

- Adds persisted UserDefaults-backed timeout settings for hierarchy requests and license handshake requests.
- Keeps the normal/default request timeout at the existing hard-coded 5s.
- Wires `LookinRequestTypeHierarchy` and `LookinRequestTypeHierarchyDetails` through `hierarchyRequestTimeoutInterval`, defaulting to 15s.
- Wires license challenge/verify requests through a separate `licenseHandshakeTimeoutInterval` key.
- Adds Preferences UI for the hierarchy timeout, plus a DEBUG-only license timeout control, with English and Simplified Chinese strings.

## Why

Hierarchy fetches can need more time on complex targets. Making the existing 15s hierarchy timeout configurable lets local builds tune that path without changing the regular 5s request behavior.

## Validation

- `git diff --check`
- `jq empty LookInside/Localizable.xcstrings`
- `xcodebuild -project LookInside.xcodeproj -scheme LookInside -configuration Debug -destination 'platform=macOS' clean build -quiet`

Note: an earlier incremental Debug build hit a stale DerivedData precompiled-header/modulemap timestamp issue; rerunning as a clean build succeeded.
