### PR TITLE
fix: sync LookinCore mirror — Swift optimization report on SwiftPM path

### DIFF
--- a/Sources/LookinCore/LookinAppInfo.m
+++ b/Sources/LookinCore/LookinAppInfo.m
@@ -142,7 +142,13 @@ static NSString * const CodingKey_DeviceType = @"8";
     
     LookinAppInfo *info = [[LookinAppInfo alloc] init];
     info.serverReadableVersion = LOOKIN_SERVER_READABLE_VERSION;
-#ifdef LOOKIN_SERVER_SWIFT_ENABLED
+// Report Swift optimization as enabled whenever the Swift-aware build is
+// compiled in. The CocoaPods subspec path defines LOOKIN_SERVER_SWIFT_ENABLED;
+// the SwiftPM / XCFramework path defines SPM_LOOKIN_SERVER_ENABLED (which in
+// turn imports LookinServerSwift and activates LOOKIN_SERVER_SWIFT_ENABLED_SUCCESSFULLY
+// in LKS_TraceManager). Both imply the optimization is active, matching the
+// contract documented on -swiftEnabledInLookinServer ("SPM 或 Swift Subspec → 1").
+#if defined(LOOKIN_SERVER_SWIFT_ENABLED) || defined(SPM_LOOKIN_SERVER_ENABLED)
     info.swiftEnabledInLookinServer = 1;
 #else
     info.swiftEnabledInLookinServer = -1;


### PR DESCRIPTION
Mirror of the canonical `LookinCore` fix in the server package: report `swiftEnabledInLookinServer = 1` when the SwiftPM / XCFramework build macro `SPM_LOOKIN_SERVER_ENABLED` is defined (in addition to the legacy CocoaPods `LOOKIN_SERVER_SWIFT_ENABLED`).

This removes the false-positive "turn on Swift optimization" notification for SwiftPM/CocoaPods consumers, which always ship the Swift-aware server binary.

Scope is limited to `Sources/LookinCore/LookinAppInfo.m` to keep this change focused.